### PR TITLE
fix: overlay 窗口初始尺寸对齐 OVERLAY_SIZE，消除首次显示黑影和重叠

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,8 +27,8 @@
       {
         "label": "overlay",
         "url": "overlay.html",
-        "width": 200,
-        "height": 48,
+        "width": 520,
+        "height": 180,
         "decorations": false,
         "transparent": true,
         "alwaysOnTop": true,


### PR DESCRIPTION
## 关联

无关联 issue。

## 改了什么

overlay 窗口在 `tauri.conf.json` 中初始尺寸为 200×48，但 `OverlayManager` 实际使用固定 520×180。首次 `set_state` 时 resize 导致透明窗口大面积暴露新区域，合成器渲染出黑影，且小窗口内内容挤在一起产生重叠。后续运行窗口已在正确尺寸，所以不复现。

将初始尺寸改为 520×180 与 `OVERLAY_SIZE` 对齐，消除首次 resize。

## 测试

- ✅ 前端 vitest：30/30 通过
- ⚠️ Rust cargo test：160 通过，10 个失败均为 Tauri 事件循环在无显示器环境下初始化的已知问题，与改动无关

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the overlay window size to provide more room for displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->