### PR TITLE
ci: 文档站等 CI 成功再部署 + 解除 fmt/clippy 阻塞

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,8 +1,12 @@
 name: Deploy Docs to GitHub Pages
 
 # Pages: 仓库 Settings → Pages → Source 选「GitHub Actions」；站点 URL 与 docs-site/docusaurus.config.ts 中 baseUrl 一致。
+# 触发方式：等 master 上的 CI 成功后再部署，避免 CI 红着却把「已修好」的文档发出去。
+# 也可在 Actions 中手动 Run workflow（workflow_dispatch）。
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [master]
   workflow_dispatch:
 
@@ -18,8 +22,13 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # workflow_run 会在 CI 失败/取消时也触发，这里只放行成功的那次；手动触发无 workflow_run 上下文，照常执行。
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # workflow_run 下锁定到触发 CI 的那个 commit；手动触发时该值为空，退回默认分支。
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ type: 简短描述
 
 - **CI**（`.github/workflows/ci.yml`）：向 `master` 推送或开 PR 时运行 `fmt` / `clippy` / `test`，下载 `packaging/scripts/download-deps.sh` 中的捆绑二进制后构建 **deb**，与发布流程一致。Windows 代码路径在 CI 中不测试（仅编译于 `cfg(windows)`），靠 Windows 手动验证。
 - **Release**（`.github/workflows/release.yml`）：推送符合 `v*` 的 **tag**（例如 `v1.5.0`）时构建 **Linux deb / rpm / Flatpak** 和 **Windows MSI**，生成 `checksums.txt` 并创建 GitHub Release。MSI 构建在 `windows-latest` runner 上执行 `pwsh packaging/scripts/download-deps-windows.ps1` + `cargo tauri build --bundles msi`。发版前请将 `src-tauri/Cargo.toml` / `tauri.conf.json` 中版本与 tag 对齐。
-- **文档站**（`.github/workflows/deploy-docs.yml`）：向 `master` 推送时构建 Docusaurus 并部署到 **GitHub Pages**。首次需在仓库 **Settings → Pages** 中将 **Build and deployment** 的 Source 设为 **GitHub Actions**（勿选 branch 静态目录）。文档地址见 `docs-site/docusaurus.config.ts` 中的 `url` / `baseUrl`（例如 `https://<org>.github.io/altgo/`）。也可在 Actions 中手动 **Run workflow** 触发部署。
+- **文档站**（`.github/workflows/deploy-docs.yml`）：`master` 上的 **CI 成功后**才构建 Docusaurus 并部署到 **GitHub Pages**（`workflow_run` 触发），避免 CI 失败时仍把文档发出去。首次需在仓库 **Settings → Pages** 中将 **Build and deployment** 的 Source 设为 **GitHub Actions**（勿选 branch 静态目录）。文档地址见 `docs-site/docusaurus.config.ts` 中的 `url` / `baseUrl`（例如 `https://<org>.github.io/altgo/`）。也可在 Actions 中手动 **Run workflow** 触发部署。
 - **AppImage**（`.github/workflows/appimage.yml`）：仅 **workflow_dispatch**，需传入与 `Cargo.toml` 一致的版本号。
 
 ## 问题反馈

--- a/src-tauri/src/key_listener/windows.rs
+++ b/src-tauri/src/key_listener/windows.rs
@@ -156,15 +156,15 @@ impl WindowsListener {
             Ok(Ok(())) => Ok((rx, BACKEND_NAME)),
             Ok(Err(message)) => {
                 self.join_hook_thread();
-                return Err(KeyListenerError::StartFailed(format!(
+                Err(KeyListenerError::StartFailed(format!(
                     "key listener start: {message}"
-                )));
+                )))
             }
             Err(_) => {
                 self.stop_hook_thread();
-                return Err(KeyListenerError::StartFailed(
+                Err(KeyListenerError::StartFailed(
                     "key listener start: timed out waiting for WH_KEYBOARD_LL hook".to_string(),
-                ));
+                ))
             }
         }
     }

--- a/src-tauri/src/transcriber.rs
+++ b/src-tauri/src/transcriber.rs
@@ -9,10 +9,10 @@
 //!
 //! 所有实现都返回 `TranscribeResult`（文本 + 语言信息），进度通过闭包回调上报。
 
-use base64::Engine;
 use crate::error::TranscriberError;
 use crate::resource::effective_threads;
 use crate::resource::expand_tilde;
+use base64::Engine;
 use regex::Regex;
 use reqwest::Client;
 use serde::Deserialize;
@@ -282,7 +282,11 @@ impl MimoAsr {
             .to_string();
 
         let language = if detected_language.is_empty() {
-            if language == "auto" { String::new() } else { language }
+            if language == "auto" {
+                String::new()
+            } else {
+                language
+            }
         } else {
             detected_language
         };

--- a/src-tauri/src/voice_pipeline/builder.rs
+++ b/src-tauri/src/voice_pipeline/builder.rs
@@ -58,11 +58,12 @@ impl PipelineBuilder {
                 cfg.timeout,
             )),
             "mimo" => {
-                let base_url = if cfg.api_base_url.is_empty() || cfg.api_base_url.contains("openai.com") {
-                    "https://api.xiaomimimo.com/v1".to_string()
-                } else {
-                    cfg.api_base_url.clone()
-                };
+                let base_url =
+                    if cfg.api_base_url.is_empty() || cfg.api_base_url.contains("openai.com") {
+                        "https://api.xiaomimimo.com/v1".to_string()
+                    } else {
+                        cfg.api_base_url.clone()
+                    };
                 let api = crate::transcriber::MimoAsr::new(
                     cfg.api_key.clone(),
                     base_url,


### PR DESCRIPTION
## 关联

无关联 issue。来自一次 CI/PR 流程体检——体检中发现 master 上 CI 已连红 6 次，遂在本 PR 一并修掉阻塞。

## 背景：CI 为什么一直红

`gh run list` 显示 master 最近 6 次 CI 全 failure。抓日志定位，根因**不是** PR #96 正文所说的「无显示器环境的 Tauri 测试」，而是 **`cargo fmt --check` 失败**——它排在 cargo 步骤第一位，一挂，后面 clippy / build / test 根本没机会跑。

## 改了什么

三个 commit，各司其职：

1. **deploy-docs 改 `workflow_run` 触发**（原始目标）
   - 原先 `on: push: branches: [master]`，与 CI 并行、互不依赖，CI 红着也会把「已修好」的文档发出去。
   - 改为监听 `CI` workflow 在 master 上 `completed`，且仅 `conclusion == 'success'`（或手动 `workflow_dispatch`）才部署；checkout 锁定到触发 CI 的 commit。
   - 同步更新 CONTRIBUTING.md 描述。

2. **修 transcriber/builder 格式**（解 fmt 阻塞）
   - v2.5.0 引入 MiMo ASR 时带进两处未格式化代码：`transcriber.rs` 的 import 排序 + 单行 if/else，`builder.rs` 的 let base_url 换行。
   - `cargo fmt` 后 `--check` 通过，纯格式化零逻辑改动。

3. **去掉 windows key_listener 两处多余 return**（clippy）
   - `cargo clippy -D warnings` 在 Windows 报 needless_return。因 CI 只在 Linux 跑、`cfg(windows)` 代码编译不到，一直没被拦下——正是「Windows 代码零 CI 覆盖」的实例。

## 验证

- ✅ `cargo fmt --check` 通过
- ✅ `cargo clippy -D warnings` 通过（本机 Windows，含 cfg(windows) 代码）
- ✅ `cargo build` 编译通过
- ⚠️ `cargo test --lib --skip tauri_sink`：本机 Windows 是 WebView2 DLL 环境问题（STATUS_ENTRYPOINT_NOT_FOUND），非测试逻辑失败；Linux CI 结果以本 PR 的 Check 为准。

## 注意

**`workflow_run` 触发器只认默认分支上的 workflow 文件**，本 PR 合入前新触发方式不生效，合并后才激活。合并后需手动验证一次：推一个 docs 改动，确认部署等 CI 绿了才开始。