### PR TITLE
ci: 抽 setup-linux-build composite action 统一系统依赖安装

### DIFF
--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -1,0 +1,34 @@
+name: 'Setup Linux Build Environment'
+description: 'Install system deps, download bundled binaries, install Tauri CLI'
+inputs:
+  enable-cuda:
+    description: 'Install CUDA toolkit'
+    required: false
+    default: 'false'
+  extra-packages:
+    description: 'Extra apt packages to install (e.g. rpm, flatpak flatpak-builder)'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf libasound2-dev build-essential cmake ${{ inputs.extra-packages }}
+    - name: Install CUDA toolkit
+      if: inputs.enable-cuda == 'true'
+      shell: bash
+      run: |
+        wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+        sudo dpkg -i cuda-keyring_1.1-1_all.deb
+        sudo apt-get update
+        sudo apt-get install -y cuda-nvcc-12-6 cuda-cudart-dev-12-6 libcublas-dev-12-6
+        echo "/usr/local/cuda-12.6/bin" >> $GITHUB_PATH
+    - name: Download bundled binaries
+      shell: bash
+      run: bash packaging/scripts/download-deps.sh x86_64
+    - name: Install Tauri CLI
+      shell: bash
+      run: cargo install tauri-cli --version "^2" --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf libasound2-dev build-essential cmake
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
         with:
           key: x86_64-unknown-linux-gnu
+
+      # 系统依赖、打包用二进制、Tauri CLI 统一在 composite action 里装
+      - uses: ./.github/actions/setup-linux-build
 
       - uses: actions/setup-node@v4
         with:
@@ -42,9 +40,6 @@ jobs:
         run: npm test
         working-directory: frontend
 
-      - name: Download bundled binaries (whisper-cli)
-        run: bash packaging/scripts/download-deps.sh x86_64
-
       - name: Check formatting
         run: cargo fmt --manifest-path=src-tauri/Cargo.toml --all -- --check
 
@@ -56,9 +51,6 @@ jobs:
 
       - name: Run tests
         run: cargo test --manifest-path=src-tauri/Cargo.toml --lib -- --skip tauri_sink
-
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "^2" --locked
 
       - name: Build Tauri GUI
         run: cargo tauri build --bundles deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf libasound2-dev build-essential cmake
-
-      - name: Install CUDA toolkit
-        run: |
-          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y cuda-nvcc-12-6 cuda-cudart-dev-12-6 libcublas-dev-12-6
-          echo "/usr/local/cuda-12.6/bin" >> $GITHUB_PATH
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-gnu
@@ -37,8 +24,9 @@ jobs:
         with:
           key: x86_64-unknown-linux-gnu-release-cuda
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "^2" --locked
+      - uses: ./.github/actions/setup-linux-build
+        with:
+          enable-cuda: 'true'
 
       - uses: actions/setup-node@v4
         with:
@@ -47,9 +35,6 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
         working-directory: frontend
-
-      - name: Download bundled binaries
-        run: bash packaging/scripts/download-deps.sh x86_64
 
       - name: Build deb
         run: cargo tauri build --bundles deb
@@ -69,19 +54,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf libasound2-dev build-essential cmake rpm
-
-      - name: Install CUDA toolkit
-        run: |
-          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y cuda-nvcc-12-6 cuda-cudart-dev-12-6 libcublas-dev-12-6
-          echo "/usr/local/cuda-12.6/bin" >> $GITHUB_PATH
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-gnu
@@ -89,8 +61,10 @@ jobs:
         with:
           key: x86_64-unknown-linux-gnu-release-rpm-cuda
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "^2" --locked
+      - uses: ./.github/actions/setup-linux-build
+        with:
+          enable-cuda: 'true'
+          extra-packages: 'rpm'
 
       - uses: actions/setup-node@v4
         with:
@@ -99,9 +73,6 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
         working-directory: frontend
-
-      - name: Download bundled binaries
-        run: bash packaging/scripts/download-deps.sh x86_64
 
       - name: Build rpm
         run: cargo tauri build --bundles rpm
@@ -121,25 +92,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf libasound2-dev build-essential cmake flatpak flatpak-builder
+      - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install CUDA toolkit
-        run: |
-          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y cuda-nvcc-12-6 cuda-cudart-dev-12-6 libcublas-dev-12-6
-          echo "/usr/local/cuda-12.6/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/setup-linux-build
+        with:
+          enable-cuda: 'true'
+          extra-packages: 'flatpak flatpak-builder'
 
       - name: Install Flatpak SDK
         run: |
           sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           sudo flatpak install -y --noninteractive flathub org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08
-
-      - uses: dtolnay/rust-toolchain@stable
 
       - uses: actions/setup-node@v4
         with:
@@ -149,13 +112,8 @@ jobs:
         run: npm ci
         working-directory: frontend
 
-      - name: Download bundled binaries
-        run: bash packaging/scripts/download-deps.sh x86_64
-
       - name: Build Tauri binary (no bundle)
-        run: |
-          cargo install tauri-cli --version "^2" --locked
-          cargo tauri build --no-bundle
+        run: cargo tauri build --no-bundle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Closes #99

## 实现方案

新建 `.github/actions/setup-linux-build` composite action，把 ci.yml 与 release.yml 里重复的安装步骤收敛为单点维护：

- **Install system dependencies**：apt 系统依赖，命令以现有 workflow 实际内容为准
- **Install CUDA toolkit**：由 `enable-cuda` 输入控制，默认 `'false'`，命令与 release.yml 原有三份 CUDA 安装一致
- **Download bundled binaries**：`bash packaging/scripts/download-deps.sh x86_64`
- **Install Tauri CLI**：`cargo install tauri-cli --version "^2" --locked`

三个 job 的 apt 包列表并不相同（rpm 多 `rpm`，flatpak 多 `flatpak flatpak-builder`），因此 action 增加 `extra-packages` 输入承载差异，避免为每个 job 各留一段重复的 apt 步骤。

调用位置统一放在 rust toolchain / rust-cache 之后：`cargo install tauri-cli` 用的是 dtolnay 固定的 stable toolchain，且编译产物能被 Swatinem/rust-cache 缓存，避免每次 CI 重编译 tauri-cli。

## flatpak 的处理决定

Flatpak SDK 安装（`flatpak remote-add` + 装 Platform/Sdk）与 apt 系通用步骤差异较大，且只服务 build-flatpak 一个 job，**保留为 job 内独立 step**，不引入 `enable-flatpak` 输入。`flatpak`/`flatpak-builder` 两个 apt 包则通过 `extra-packages` 传入 action。注意该 step 必须排在 action 之后，因为它依赖 action 装好的 flatpak 命令。

## 验收 checklist

- [x] 安装步骤单点维护，全部收敛到 `.github/actions/setup-linux-build/action.yml`
- [x] `enable-cuda` 默认 `'false'`，ci.yml 不传，release 三个 Linux job 传 `'true'`
- [x] ci.yml / release.yml 中被替换的原步骤（apt、CUDA、download-deps、tauri-cli）均已删除，Linux 侧无残留重复（Windows job 的 tauri-cli 与 download-deps-windows.ps1 不在本 issue 范围）
- [x] 三个 YAML 文件均通过 `yaml.safe_load` 语法校验
