### PR TITLE
test: tauri_sink 测试改为仅 Windows 编译，CI 去掉整体 skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: cargo build --release --manifest-path=src-tauri/Cargo.toml
 
       - name: Run tests
-        run: cargo test --manifest-path=src-tauri/Cargo.toml --lib -- --skip tauri_sink
+        run: cargo test --manifest-path=src-tauri/Cargo.toml --lib
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version "^2" --locked

--- a/src-tauri/src/tauri_sink.rs
+++ b/src-tauri/src/tauri_sink.rs
@@ -128,7 +128,10 @@ impl PipelineSink for TauriPipelineSink {
     }
 }
 
-#[cfg(test)]
+// 测试 fixture 需要构建真实 Wry app。Linux 上 tao::EventLoop 只能在主线程
+// 初始化，而 libtest 在工作线程跑用例，构建必然 panic，故整个测试模块只在
+// Windows 编译运行（CI 由 windows-check job 覆盖，见 ci.yml）。
+#[cfg(all(test, windows))]
 mod tests {
     use super::*;
     use crate::overlay::seam::OverlayPhase;


### PR DESCRIPTION
Closes #100

## 与 issue 设想的偏差（重要）

Issue 假设 tauri_sink 模块里存在「不依赖 tauri runtime 的纯逻辑测试」，実际读码后**不成立**：模块内全部 10 个测试都走 `make_fixture` → `tauri::Builder::<Wry>::default().build(...)`，每个用例都需要真实 Wry app（要 `AppHandle` 才能构造 `TauriPipelineSink`）。

真正的阻塞也不是「无显示器」，见 42432d3 的提交说明：**Linux 上 tao::EventLoop 只能在主线程初始化，而 libtest 在工作线程跑用例**，构建 app 必然 panic。xvfb 只能解决显示器，解决不了线程问题，所以「xvfb-run 跑全部测试」这条路也不通。

## 方案

- `tauri_sink.rs`：整个 `mod tests` 加 `#[cfg(all(test, windows))]`（Windows 上 tao 允许非主线程建 EventLoop，这批测试本来就是在 Windows 上开发通过的）
- `ci.yml`：`cargo test --lib` 去掉 `--skip tauri_sink`（Linux 上这些用例已不再编译，skip 成为死配置）

这批用例的 CI 覆盖由 #98 的 Windows job 承接（本 PR 合入后跟进），净效果是从「全平台跳过」变为「Windows CI 真实运行」。

## 备选方案（未采用）

把 `on_status_change` 的状态映射逻辑抽成不依赖 `AppHandle` 的纯函数、在 Linux 测纯函数。可行但要为测试改生产代码结构，而 Windows job 落地后现有测试已完整覆盖同一逻辑，收益不抵改动。

## 验证

- 本地（Windows）：`cargo fmt --check` 通过；`cargo clippy -- -D warnings`（CI 同款命令）通过；`cargo test --lib --no-run` 编译通过
- 本机 `cargo test --lib` 运行期受已知 WebView2 DLL 问题（0xc0000139）影响无法执行，与本次改动无关，测试逻辑以 CI 结果为准
- Linux 无显示器环境下 `cargo test --lib` 全绿：以本 PR 的 Check job 为准

## 验收对照

- [x] CI 不再 `--skip tauri_sink`
- [x] 需要 runtime 的测试被合理处理（改为平台 gate，不再脏 skip 整个模块）
- [ ] 本地 `cargo test --lib` 全绿 —— 本机 WebView2 环境问题无法执行，见上
- [ ] 合入后 master CI 仍绿