### PR TITLE
ci: 加 Windows Check job（fmt + clippy + test，不打包）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,29 @@ jobs:
         run: cargo tauri build --bundles deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Windows 只验证不打包：fmt + clippy + test，拦住 cfg(windows) 代码的问题
+  # （Linux job 编译不到那段）。tauri_sink 测试仅 Windows 编译（#100），
+  # 其 CI 覆盖由本 job 承接。
+  windows-check:
+    name: Windows Check
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: x86_64-pc-windows-msvc
+
+      - name: Check formatting
+        run: cargo fmt --manifest-path=src-tauri/Cargo.toml --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --manifest-path=src-tauri/Cargo.toml -- -D warnings
+
+      - name: Run tests
+        run: cargo test --manifest-path=src-tauri/Cargo.toml --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,5 +80,8 @@ jobs:
       - name: Clippy
         run: cargo clippy --manifest-path=src-tauri/Cargo.toml -- -D warnings
 
+      # tauri_sink 测试的 fixture 要构建真实 Wry app，tao 要求 EventLoop 在
+      # 主线程初始化（Windows/Linux 同样限制），libtest 在工作线程跑用例，
+      # 这批测试在任何平台的 cargo test 下都无法运行，精确跳过。
       - name: Run tests
-        run: cargo test --manifest-path=src-tauri/Cargo.toml --lib
+        run: cargo test --manifest-path=src-tauri/Cargo.toml --lib -- --skip tauri_sink

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -7,7 +7,27 @@ const PLACEHOLDER: &str = "00_tauri_deps_placeholder.txt";
 
 fn main() {
     sync_deps_bin_placeholder();
-    tauri_build::build();
+
+    // exe 和 lib 测试二进制都链接 rfd（tauri-plugin-dialog 的依赖），其静态
+    // 导入 TaskDialogIndirect 只有 comctl32 v6 才导出。tauri-build 默认以
+    // 资源形式给 exe 嵌入 manifest，测试二进制没有，进程启动即
+    // STATUS_ENTRYPOINT_NOT_FOUND（0xc0000139），Windows 上整个测试套件
+    // 无法运行。改为关掉 tauri-build 的 manifest 资源嵌入（避免与链接参数
+    // 产生重复资源 CVT1100），统一用 /MANIFESTINPUT 链接参数注入同一份
+    // manifest，exe 与测试二进制同时覆盖。
+    let attrs = tauri_build::Attributes::new()
+        .windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest());
+    tauri_build::try_build(attrs).expect("failed to run tauri-build");
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        let manifest = PathBuf::from(
+            std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set"),
+        )
+        .join("windows-app-manifest.xml");
+        println!("cargo:rerun-if-changed={}", manifest.display());
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!("cargo:rustc-link-arg=/MANIFESTINPUT:{}", manifest.display());
+    }
 }
 
 fn sync_deps_bin_placeholder() {

--- a/src-tauri/windows-app-manifest.xml
+++ b/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- 应用 manifest：exe 与 lib 测试二进制共用（build.rs 以 /MANIFESTINPUT 注入）。
+     内容与 tauri-build 的默认 manifest 相同：声明 comctl32 v6 依赖。
+     rfd（tauri-plugin-dialog 的依赖）静态导入 TaskDialogIndirect，
+     该函数只有 comctl32 v6 导出，缺此 manifest 的进程启动即 0xc0000139。 -->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
Closes #98

## 改动

`ci.yml` 新增 `windows-check` job（`runs-on: windows-latest`）：fmt、clippy、`cargo test --lib -- --skip tauri_sink`。不装 GTK/WebKit、不跑 `cargo tauri build`，成本低。

- job name `Windows Check`，不与 required check `Check` 冲突
- `Swatinem/rust-cache` key 用 `x86_64-pc-windows-msvc`，与 Linux 缓存隔离

## 顺带的两个发现与修复（本 PR 范围内）

**1. Windows 上 cargo test 长期跑不了（0xc0000139），根因不是 WebView2**

首轮 CI 上 Windows job 的 fmt/clippy 过了，但 test 二进制启动即 `STATUS_ENTRYPOINT_NOT_FOUND`，与本机现象完全一致。逐个核对 400 项 DLL 导入后定位到 `comctl32.dll -> TaskDialogIndirect`：rfd（tauri-plugin-dialog 依赖）静态导入该函数，只有 comctl32 v6 导出；tauri-build 只给 exe 嵌入 manifest（其默认 manifest 本就含 v6 声明），测试二进制没有，进程加载即失败。

修复（`build.rs` + 新增 `src-tauri/windows-app-manifest.xml`）：关掉 tauri-build 的 manifest 资源嵌入（`new_without_app_manifest`，避免与链接参数产生重复资源 CVT1100），统一用 `cargo:rustc-link-arg=/MANIFESTINPUT` 把同一份 manifest（内容同 tauri 默认）注入 exe 与测试二进制。本地验证：exe 构建正常，两个二进制均确认嵌入 v6 manifest。

**2. tauri_sink 的 10 个测试在 Windows 上也跑不了**

修好启动问题后实测：tao 0.34 在 Windows 同样禁止非主线程创建 EventLoop（#100 时以为仅 Linux 受限），libtest 在工作线程跑用例，fixture 构建 Wry app 必然 panic。这批测试在 libtest 下任何平台都无法运行——它从未在任何 CI/本机真实跑过。故 Windows job 精确 `--skip tauri_sink`，与 #100 在 Linux 的处理对齐；要真正救活它们需要重做 fixture（不依赖真实 Wry app），另开 issue 跟进。

## 验证

- 本地（Windows）：`cargo test --lib -- --skip tauri_sink` 168 通过、0 失败；`cargo build` 正常；fmt/clippy 干净
- Windows runner 表现以本 PR CI 为准

## 验收对照

- [x] Windows runner 上 fmt + clippy + test 成功（以本 PR CI 为准）
- [x] job name 不与 `Check` 冲突
- [x] rust-cache key 独立于 Linux
- [x] 能拦住 cfg(windows) 问题（clippy 编译 Windows 代码路径）