### PR TITLE
release: v2.5.4 文档纠错与发版

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.5.4 (2026-08-09)
+
+### Docs
+
+- **README 文本润色**：精简开头与若干冗余表述，统一在线文档链接文本。
+- **安装章节对齐实际产物**：release 实际提供 deb / rpm / Flatpak / MSI，README 此前提了从未上架的 AppImage；改为列出三种 Linux 格式并补 rpm / Flatpak 安装命令，Releases 链接改用完整 URL。
+- **清理过时的 AppImage / ffmpeg 引用**：docs-site（quick-start、usage、首页）与 CONTRIBUTING 同步更新；CONTRIBUTING 删除指向已不存在的 `appimage.yml` workflow 的条目。
+
+### Fixes
+
+- **`build.ps1` 的 ffmpeg 残留检查**：v2.5.1 移除 ffmpeg 后漏改，`ffmpeg.exe` 检查恒为缺失、每次构建白跑一遍 `download-deps-windows.ps1`；改为只检查 `whisper-cli.exe`。
+
 ## v2.5.3 (2026-07-22)
 
 ### CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **README 文本润色**：精简开头与若干冗余表述，统一在线文档链接文本。
 - **安装章节对齐实际产物**：release 实际提供 deb / rpm / Flatpak / MSI，README 此前提了从未上架的 AppImage；改为列出三种 Linux 格式并补 rpm / Flatpak 安装命令，Releases 链接改用完整 URL。
 - **清理过时的 AppImage / ffmpeg 引用**：docs-site（quick-start、usage、首页）与 CONTRIBUTING 同步更新；CONTRIBUTING 删除指向已不存在的 `appimage.yml` workflow 的条目。
+- **移除 README 中已废弃的「桌面通知」描述**：桌面通知在 v2.4.5（#63）随 notify 输出路径删除，README 仍保留该功能描述；本次清除功能列表、设置、架构图、模块表中的过时引用。
 
 ### Fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,6 @@ type: 简短描述
 - **CI**（`.github/workflows/ci.yml`）：向 `master` 推送或开 PR 时运行 `fmt` / `clippy` / `test`，下载 `packaging/scripts/download-deps.sh` 中的捆绑二进制后构建 **deb**，与发布流程一致。Windows 代码路径在 CI 中不测试（仅编译于 `cfg(windows)`），靠 Windows 手动验证。
 - **Release**（`.github/workflows/release.yml`）：推送符合 `v*` 的 **tag**（例如 `v1.5.0`）时构建 **Linux deb / rpm / Flatpak** 和 **Windows MSI**，生成 `checksums.txt` 并创建 GitHub Release。MSI 构建在 `windows-latest` runner 上执行 `pwsh packaging/scripts/download-deps-windows.ps1` + `cargo tauri build --bundles msi`。发版前请将 `src-tauri/Cargo.toml` / `tauri.conf.json` 中版本与 tag 对齐。
 - **文档站**（`.github/workflows/deploy-docs.yml`）：`master` 上的 **CI 成功后**才构建 Docusaurus 并部署到 **GitHub Pages**（`workflow_run` 触发），避免 CI 失败时仍把文档发出去。首次需在仓库 **Settings → Pages** 中将 **Build and deployment** 的 Source 设为 **GitHub Actions**（勿选 branch 静态目录）。文档地址见 `docs-site/docusaurus.config.ts` 中的 `url` / `baseUrl`（例如 `https://<org>.github.io/altgo/`）。也可在 Actions 中手动 **Run workflow** 触发部署。
-- **AppImage**（`.github/workflows/appimage.yml`）：仅 **workflow_dispatch**，需传入与 `Cargo.toml` 一致的版本号。
 
 ## 问题反馈
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **无需打字，言出法随** — 语音转文字桌面工具（Linux + Windows）
 
-按住右 Alt 键说话，松开后在本地用 **whisper.cpp** 转写，可选通过 **OpenAI 兼容 API 或 Anthropic Messages API** 调用 LLM 润色；成功后**会尝试将结果写入系统剪贴板**，并在**悬浮窗**中展示，便于核对；也可在悬浮窗内再次点击复制（例如剪贴板工具不可用或需二次确认时）。所有转写文本（原始 + 润色后）会自动保存到本地**历史记录**，随时可查、可复制、可再次润色。
+按住右 Alt 键说话，松开后在本地用 **whisper.cpp** 转写，可选通过 **OpenAI 兼容 API 或 Anthropic Messages API** 调用 LLM 润色。结果写入系统剪贴板，同时在**悬浮窗**中展示便于核对；若剪贴板写入失败或想再次确认，可在悬浮窗内点按复制。所有转写文本（原始 + 润色后）自动保存到本地**历史记录**，随时可查、可复制、可再次润色。
 
-**在线文档**：[https://cislunarspace.github.io/altgo/](https://cislunarspace.github.io/altgo/)（源码在 [`docs-site/`](docs-site/)，由 GitHub Pages 部署）。
+**在线文档**：[cislunarspace.github.io/altgo](https://cislunarspace.github.io/altgo/)（源码在 [`docs-site/`](docs-site/)，由 GitHub Pages 部署）。
 
 支持 **Linux**（Ubuntu 20.04+）和 **Windows**（MSI 安装包，GitHub Releases 提供）。不支持 macOS。
 
@@ -18,7 +18,7 @@
 - **常驻转写提速**：本地模式下自动拉起常驻 **whisper-server**，模型只载入内存一次，之后每句话走本地 HTTP 转写，省去逐句重载模型的冷启动开销；若 whisper-server 不可用，自动回退到一次性 `whisper-cli`
 - **LLM 润色（可选）**：通过 **OpenAI 兼容 API** 或 **Anthropic Messages API** 调用任意厂商或本地部署的 LLM（如云端 API、Ollama、vLLM 等），对转写文本做 light / medium / heavy 等档位润色
 - **悬浮窗与剪贴板**：处理完成后写入剪贴板并弹出悬浮窗；可在悬浮窗内再次复制
-- **桌面通知**：处理完成时可伴随通知提示（依配置）
+- **桌面通知**：处理完成时弹出系统通知（可在设置中开关）
 - **系统托盘**：常驻托盘图标，左键显示/隐藏主窗口，右键菜单提供退出选项
 - **转写历史**：所有成功转写自动保存到本地 `history.json`；支持查看列表、复制、删除单条、清空全部，以及对任意记录**再次润色**
 
@@ -34,7 +34,7 @@
   # 注销并重新登录，或重启后再试
   ```
 
-- **其余系统组件**（如与桌面、音频、通知相关的库）由 **`.deb` 的依赖关系** 或发行说明处理：缺什么按安装器提示补装即可，不必手工对照长清单。
+- **其余系统组件**（桌面、音频、通知相关库）由 **`.deb` 依赖**自动处理，缺什么按安装器提示补装即可。
 
 ### Windows
 
@@ -48,29 +48,28 @@
 
 #### Linux
 
-1. 前往 [Releases](../../releases) 下载 **`.deb`** 或 **AppImage**。
-2. 安装 **`.deb`**（Ubuntu / Debian 系）：
-   - **推荐**用 `apt` 从本地文件安装，会**自动处理**依赖（如 GTK / WebKit、系统托盘、剪贴板工具等）：
+1. 前往 [Releases](https://github.com/cislunarspace/altgo/releases) 下载对应发行版的安装包：
+   - **`.deb`**（Ubuntu / Debian 系）
+   - **`.rpm`**（Fedora / RHEL 系）
+   - **`.flatpak`**（任意发行版，需已安装 Flatpak）
+2. 安装（按下载的格式选其一）：
+   - **`.deb`**：推荐用 `apt` 从本地文件安装，会自动处理依赖（GTK / WebKit、系统托盘、剪贴板工具等）：
 
      ```bash
      sudo apt install /path/to/altgo_*_amd64.deb
      ```
 
      将路径换成你保存 deb 的实际位置；在 deb 所在目录时也可写 `sudo apt install ./altgo_*.deb`。
-   - **不建议只用** `sudo dpkg -i …`：dpkg 不会拉取依赖，容易因缺包导致安装不完整。若已用 dpkg 装到一半失败，执行 `sudo apt install -f` 补全依赖。
-   - **AppImage**：赋予执行权限即可运行，无需安装：
-
-     ```bash
-     chmod +x /path/to/altgo-*.AppImage
-     /path/to/altgo-*.AppImage
-     ```
+     不建议只用 `sudo dpkg -i …`：dpkg 不拉依赖，容易缺包；若已装到一半失败，用 `sudo apt install -f` 补全。
+   - **`.rpm`**：`sudo dnf install /path/to/altgo-*.rpm`（自动拉依赖）；无 dnf 时用 `sudo rpm -i …`，需自行保证依赖。
+   - **`.flatpak`**：`flatpak install --user /path/to/altgo-x86_64.flatpak`，首次安装会自动拉取 Flatpak 运行时；之后从应用菜单启动，或 `flatpak run com.github.altgo`。
 
 3. **务必**完成 [系统要求](#linux) 中的 **`input` 组** 步骤（与按键监听相关，安装包无法代劳）。
 4. 启动应用，在 **[设置](#首次使用应用内设置)** 里完成转写模型与可选润色等；**不要**一上来编辑配置文件。
 
 #### Windows
 
-1. 前往 [Releases](../../releases) 下载 **`.msi`** 安装包。
+1. 前往 [Releases](https://github.com/cislunarspace/altgo/releases) 下载 **`.msi`** 安装包。
 2. 双击运行 MSI，按向导完成安装。首次安装时若系统缺少 **WebView2 运行时**，安装程序会自动下载并安装（需联网）。
 3. 启动应用，在 **[设置](#首次使用应用内设置)** 里完成转写模型与可选润色等。
 
@@ -225,7 +224,7 @@ cargo test --manifest-path=src-tauri/Cargo.toml
 
 ## 相关文档
 
-- **用户向站点**：[https://cislunarspace.github.io/altgo/](https://cislunarspace.github.io/altgo/) · 源码 [`docs-site/`](docs-site/)
+- **用户向站点**：[cislunarspace.github.io/altgo](https://cislunarspace.github.io/altgo/) · 源码 [`docs-site/`](docs-site/)
 - [CONTRIBUTING.md](CONTRIBUTING.md)（含 **CI / Release / GitHub Pages** 维护说明）
 - [CLAUDE.md](CLAUDE.md)（面向 AI/贡献者的架构速览）
 - [docs/](docs/)（维护者用的设计与计划归档，见 [`docs/README.md`](docs/README.md)）

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 - **常驻转写提速**：本地模式下自动拉起常驻 **whisper-server**，模型只载入内存一次，之后每句话走本地 HTTP 转写，省去逐句重载模型的冷启动开销；若 whisper-server 不可用，自动回退到一次性 `whisper-cli`
 - **LLM 润色（可选）**：通过 **OpenAI 兼容 API** 或 **Anthropic Messages API** 调用任意厂商或本地部署的 LLM（如云端 API、Ollama、vLLM 等），对转写文本做 light / medium / heavy 等档位润色
 - **悬浮窗与剪贴板**：处理完成后写入剪贴板并弹出悬浮窗；可在悬浮窗内再次复制
-- **桌面通知**：处理完成时弹出系统通知（可在设置中开关）
 - **系统托盘**：常驻托盘图标，左键显示/隐藏主窗口，右键菜单提供退出选项
 - **转写历史**：所有成功转写自动保存到本地 `history.json`；支持查看列表、复制、删除单条、清空全部，以及对任意记录**再次润色**
 
@@ -34,7 +33,7 @@
   # 注销并重新登录，或重启后再试
   ```
 
-- **其余系统组件**（桌面、音频、通知相关库）由 **`.deb` 依赖**自动处理，缺什么按安装器提示补装即可。
+- **其余系统组件**（桌面、音频相关库）由 **`.deb` 依赖**自动处理，缺什么按安装器提示补装即可。
 
 ### Windows
 
@@ -110,7 +109,6 @@ cd frontend; npm install; cd ..
 - **润色**：选择是否启用以及轻/中/重度；选择 API 协议（OpenAI 兼容 或 Anthropic）；填写地址、模型名与密钥（适用于云端或本地网关如 Ollama 等）。
 - **外观**：浅色 / 深色 / 跟随系统；**界面语言**。
 - **录音 / 触发键**：预设左右 Alt 或 **「按下以设置」** 捕获快捷键。
-- **输出**：开关桌面通知、剪贴板行为等。
 - 点击 **保存**；多数情况下管道会自动重载，无需重启应用。
 
 跟着界面走即可完成日常使用。
@@ -167,7 +165,7 @@ cd frontend; npm install; cd ..
 ## 架构
 
 ```text
-按键事件 → 状态机 → 录音 → whisper.cpp 转写 → 可选 LLM 润色 → 悬浮窗展示 + 剪贴板 + 通知 + 历史记录持久化
+按键事件 → 状态机 → 录音 → whisper.cpp 转写 → 可选 LLM 润色 → 悬浮窗展示 + 剪贴板 + 历史记录持久化
 ```
 
 altgo 基于 **Tauri**，前端 **React**，核心逻辑 **Rust**。关键模块包括：
@@ -179,7 +177,7 @@ altgo 基于 **Tauri**，前端 **React**，核心逻辑 **Rust**。关键模块
 | `recorder` | 音频采集（Linux: parecord / Windows: cpal-WASAPI） |
 | `transcriber` | 本地常驻 whisper-server（回退 `whisper-cli`）或 OpenAI 兼容 API 转写 |
 | `polisher` | OpenAI 兼容 API 或 Anthropic Messages API 润色 |
-| `output` | 剪贴板写入（Linux: xclip/xsel/wl-copy / Windows: arboard）、桌面通知 |
+| `output` | 剪贴板写入（Linux: xclip/xsel/wl-copy / Windows: arboard） |
 | `history` | 本地 `history.json` 的追加 / 列表 / 删除 / 更新 |
 | `model` | GGML 模型下载与管理 |
 

--- a/docs-site/docs/quick-start.mdx
+++ b/docs-site/docs/quick-start.mdx
@@ -7,7 +7,7 @@ title: 快速开始
 
 本软件支持 **Linux**（Ubuntu 20.04+）和 **Windows**。Linux 目前仅在 **Ubuntu 20.04** 上做过测试与部署验证；其他发行版可能可用但未保证。Windows 通过 MSI 安装包提供。
 
-**官方预编译包**（deb / AppImage）会尽量把 **ffmpeg**、**whisper-cli** 等与程序一并打包，安装后**开箱即用**，无需再为录音、转写单独安装这些二进制。
+**官方预编译包**（deb / rpm / Flatpak）会把 **whisper-cli** 与程序一并打包，安装后**开箱即用**，无需再为转写单独安装二进制。
 
 ## Linux：安装前必做（input 组）
 
@@ -23,7 +23,7 @@ sudo usermod -aG input "$USER"
 
 ### Linux
 
-1. 从 [Releases](https://github.com/cislunarspace/altgo/releases) 安装 **`.deb`** 或使用 **AppImage**（`chmod +x` 后运行）。
+1. 从 [Releases](https://github.com/cislunarspace/altgo/releases) 下载对应发行版的安装包：**`.deb`**（Ubuntu/Debian）、**`.rpm`**（Fedora/RHEL）或 **`.flatpak`**。
 2. 完成上文 **input 组**。
 3. 启动应用，打开 **设置**：
    - 在 **转写** 中选用 **本地** 或 **API**（若需要），下载并启用模型，或填写高级路径；
@@ -58,7 +58,7 @@ make build
 
 若需快速改前端 UI，可临时使用 `cargo tauri dev`；完整链路仍以 `make build` 为准。
 
-**Windows**：用 `.\build.ps1` 或 `build.cmd` 替代 `make build`（自动下载 whisper-cli、ffmpeg 后 `cargo tauri build --bundles msi`）。需已安装 Rust（MSVC 工具链）、Node.js、PowerShell 7+。
+**Windows**：用 `.\build.ps1` 或 `build.cmd` 替代 `make build`（自动下载 whisper-cli 后 `cargo tauri build --bundles msi`）。需已安装 Rust（MSVC 工具链）、Node.js、PowerShell 7+。
 
 ## 高级：仅当你要手改配置文件时
 

--- a/docs-site/docs/usage.mdx
+++ b/docs-site/docs/usage.mdx
@@ -70,7 +70,7 @@ cd frontend && npm install && cd ..
 cargo tauri dev
 ```
 
-完整发布链路（含捆绑 `ffmpeg` / `whisper-cli`）：
+完整发布链路（含捆绑 `whisper-cli`）：
 - **Linux**：以仓库根目录的 **`make build`** 为准，与 CI 一致。
 - **Windows**：以 **`.\build.ps1`**（或 `build.cmd`）为准。
 

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -160,7 +160,7 @@ export default function Home(): JSX.Element {
                 <div className={styles.stepNum}>1</div>
                 <h3>安装并设置</h3>
                 <p>
-                  下载 deb / AppImage 安装包，在设置中选择转写引擎与模型。
+                  下载 deb / rpm / Flatpak / MSI 安装包，在设置中选择转写引擎与模型。
                 </p>
               </div>
               <ArrowRight className={styles.stepArrow} size={24} />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "altgo-frontend",
   "private": true,
-  "version": "2.5.3",
+  "version": "2.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packaging/scripts/build.ps1
+++ b/packaging/scripts/build.ps1
@@ -1,4 +1,4 @@
-# 与 Linux 上 `make build` 等价：按需拉取 ffmpeg / whisper-cli → cargo tauri build → 拷贝到 src-tauri/target/release/bin/
+# 与 Linux 上 `make build` 等价：按需拉取 whisper-cli → cargo tauri build → 拷贝到 src-tauri/target/release/bin/
 # 在仓库根目录执行：pwsh packaging/scripts/build.ps1
 # 亦可使用根目录的 .\build.ps1
 
@@ -10,11 +10,10 @@ Set-Location $RepoRoot
 
 $BinDeps = Join-Path $RepoRoot "target/deps/bin"
 $Placeholder = "00_tauri_deps_placeholder.txt"
-$Ffmpeg = Join-Path $BinDeps "ffmpeg.exe"
 $Whisper = Join-Path $BinDeps "whisper-cli.exe"
 
-if (-not (Test-Path $Ffmpeg) -or -not (Test-Path $Whisper)) {
-    Write-Host "[INFO] Missing ffmpeg.exe or whisper-cli.exe under target/deps/bin — running download-deps.ps1" `
+if (-not (Test-Path $Whisper)) {
+    Write-Host "[INFO] Missing whisper-cli.exe under target/deps/bin — running download-deps.ps1" `
         -ForegroundColor Cyan
     & (Join-Path $ScriptDir "download-deps-windows.ps1")
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "altgo-tauri"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "altgo-tauri"
-version = "2.5.3"
+version = "2.5.4"
 edition = "2021"
 description = "altgo Tauri desktop application"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "altgo",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "identifier": "com.altgo.app",
   "build": {
     "beforeDevCommand": "npm --prefix ../frontend run dev",


### PR DESCRIPTION
## 关联

无关联 issue（文档纠错与发版，用户直接发起）。

## 改了什么

发版 **v2.5.4**，主体是文档纠错 + 一处 v2.5.1 漏网的脚本残留：

- **docs**：README 文本润色；安装章节重写——release 实际提供 deb / rpm / Flatpak / MSI，原文却提了从未上架的 AppImage，改为列出三种 Linux 格式并补 rpm / Flatpak 安装命令，Releases 链接改完整 URL。
- **docs**：docs-site（quick-start、usage、首页 index）与 CONTRIBUTING 同步去掉 AppImage / ffmpeg 引用；CONTRIBUTING 删除指向不存在的 `appimage.yml` workflow 的条目。
- **fix(packaging)**：build.ps1 移除 v2.5.1 漏删的 ffmpeg 残留检查（`ffmpeg.exe` 恒缺失、每次构建白跑一遍 download-deps-windows.ps1），改为只检查 `whisper-cli.exe`。
- **release**：`2.5.3 → 2.5.4`（Cargo.toml / Cargo.lock / tauri.conf.json / package.json），CHANGELOG 加 v2.5.4 条目。

## 测试

- `cargo fmt --check`：通过。
- `cargo check` / `cargo clippy`：本机缺 WebKit 开发库（cairo / libsoup）跑不通，非改动问题，CI 会装库验证。
- `Cargo.lock` 一致性：grep 确认 `altgo-tauri` 两边均为 `2.5.4`，沿用 v2.5.3 release commit 的手改方式。

## 备注

- `packaging/appimage/` 死代码（无 workflow、产物从未上架）保留未删，属另一决策，建议另起 PR。
- Flatpak 安装命令（`flatpak install --user ... && flatpak run com.github.altgo`）基于 release.yml 推断（app id `com.github.altgo`），建议在 Linux 实测。