### PR TITLE
ci: 加 whisper-prebuild workflow（预编译 whisper 产物复用）

### DIFF
--- a/.github/workflows/whisper-prebuild.yml
+++ b/.github/workflows/whisper-prebuild.yml
@@ -1,0 +1,108 @@
+name: Whisper Prebuild
+
+# 一次性预编译 whisper.cpp 产物（Linux x86_64，CUDA 版），上传到独立 release。
+# download-deps.sh 优先从此 release 下载，省去每个 release job 各编译一遍 whisper。
+# whisper 版本变化（versions.sh / versions.json 改）时自动触发；也可手动跑。
+
+on:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: '强制重建并覆盖（即使该版本 release 已存在）'
+        required: false
+        default: 'false'
+  push:
+    branches: [master]
+    paths:
+      - 'packaging/scripts/versions.sh'
+      - 'packaging/scripts/versions.json'
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  prebuild:
+    name: Prebuild whisper deps (Linux x86_64 + CUDA)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read whisper version
+        id: ver
+        shell: bash
+        run: |
+          source packaging/scripts/versions.sh
+          echo "whisper=${WHISPER_CPP_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=whisper-deps-${WHISPER_CPP_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "asset=whisper-deps-${WHISPER_CPP_VERSION}-x86_64.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Check if already prebuilt
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="${{ steps.ver.outputs.tag }}"
+          ASSET="${{ steps.ver.outputs.asset }}"
+          FORCE="${{ github.event.inputs.force || 'false' }}"
+          exists=0
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && \
+             gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' 2>/dev/null | grep -qx "$ASSET"; then
+            exists=1
+          fi
+          if [ "$exists" = "1" ] && [ "$FORCE" != "true" ]; then
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+            echo "[INFO] $TAG / $ASSET already exists — skipping (workflow_dispatch with force=true to rebuild)."
+          else
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+            echo "[INFO] Will prebuild (exists=$exists, force=$FORCE)."
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.check.outputs.should_skip != 'true'
+
+      - uses: ./.github/actions/setup-linux-build
+        if: steps.check.outputs.should_skip != 'true'
+        with:
+          enable-cuda: 'true'
+
+      - name: Verify whisper artifacts
+        if: steps.check.outputs.should_skip != 'true'
+        shell: bash
+        run: |
+          echo "--- target/deps/bin/ 内容 ---"
+          ls -la target/deps/bin/
+          test -x target/deps/bin/whisper-cli
+          test -x target/deps/bin/whisper-server
+          test "$(find target/deps/bin -maxdepth 1 -name 'libwhisper.so*' ! -type l | wc -l)" -ge 1
+          test "$(find target/deps/bin -maxdepth 1 -name 'libggml.so*' ! -type l | wc -l)" -ge 1
+          test "$(find target/deps/bin -maxdepth 1 -name 'libggml-cuda.so*' ! -type l | wc -l)" -ge 1
+          echo "[OK] whisper-cli / whisper-server / libwhisper.so / libggml.so / libggml-cuda.so 齐全"
+
+      - name: Package deps
+        if: steps.check.outputs.should_skip != 'true'
+        shell: bash
+        run: |
+          asset="${{ steps.ver.outputs.asset }}"
+          tar -C target/deps -czf "$asset" bin
+          echo "--- tarball 内容 ---"
+          tar -tzf "$asset"
+          ls -lh "$asset"
+
+      - name: Upload to release
+        if: steps.check.outputs.should_skip != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          name: whisper-deps ${{ steps.ver.outputs.whisper }}
+          body: |
+            预编译 whisper.cpp 产物（Linux x86_64，CUDA 版），供 `download-deps.sh` 下载复用。
+
+            - whisper.cpp 版本: `${{ steps.ver.outputs.whisper }}`
+            - 含: `whisper-cli` / `whisper-server` / `libwhisper.so` / `libggml.so` / `libggml-cuda.so`
+            - CUDA 版作通用产物：无 N 卡的机器 `libggml-cuda.so` 经 dlopen 加载失败会自动回退 CPU（构建时 `GGML_CUDA_NO_VMM=ON` 保证不硬依赖 `libcuda`）。
+            - 由 `whisper-prebuild` workflow 在 ubuntu-22.04 + CUDA 12.6 上构建。
+          files: ${{ steps.ver.outputs.asset }}


### PR DESCRIPTION
## 关联

无关联 issue（release 提速优化）。

## 背景

release 每次 60–144 分钟，主因：三个 Linux job 各自装 CUDA toolkit + 源码编译 whisper（15–25 分钟/个）。Windows 下载预编译，所以 18 分钟完成。

## 改了什么

新增 `whisper-prebuild.yml` workflow（**零风险**：不改现有 release.yml / ci.yml）：

- 在 ubuntu-22.04 + CUDA 上源码编译 whisper 全套产物（`whisper-cli` / `whisper-server` / `libwhisper.so` / `libggml.so` / `libggml-cuda.so`），打成 tarball。
- 上传到独立 release tag `whisper-deps-<WHISPER_CPP_VERSION>`。
- 触发：`workflow_dispatch`（手动，含 force 覆盖）+ push 到 `versions.sh`/`versions.json`（whisper 升级自动重编）。
- 已有产物且 force=false 时跳过，避免重复编译。

## 后续（另起 PR）

1. `download-deps.sh` 改造：下载优先 + 源码回退。
2. `release.yml` / `ci.yml` 去掉 `enable-cuda`（下载预编译不需 nvcc）。

## 测试

- YAML 本地校验通过（jobs: prebuild）。
- **GitHub 限制**：`workflow_dispatch` 只能触发默认分支注册的 workflow，本 workflow 需合并到 master 后才能触发首次预编译验证。合并后我会触发并验证产物完整性（5 类文件齐全 + 解压可用）。
- 当前 v2.5.4 release 不受影响（本 PR 不改现有流程）。