### PR TITLE
ci: download-deps.sh 优先下载预编译 whisper，省去逐 job 源码编译

### DIFF
--- a/.github/workflows/whisper-prebuild.yml
+++ b/.github/workflows/whisper-prebuild.yml
@@ -10,12 +10,18 @@ on:
       force:
         description: '强制重建并覆盖（即使该版本 release 已存在）'
         required: false
-        default: 'false'
+        type: boolean
+        default: false
   push:
     branches: [master]
     paths:
       - 'packaging/scripts/versions.sh'
       - 'packaging/scripts/versions.json'
+
+# 单次编译约 50 分钟，避免同一版本并发重复构建（后上传者覆盖先者，纯浪费）。
+concurrency:
+  group: whisper-prebuild
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -27,6 +33,10 @@ jobs:
   prebuild:
     name: Prebuild whisper deps (Linux x86_64 + CUDA)
     runs-on: ubuntu-22.04
+    env:
+      # 本 job 是"源码重建"，必须绕过 download-deps.sh 的预编译下载路径，
+      # 否则 force 重建会从 release 拉回旧产物而非真正重编。
+      ALTGO_WHISPER_SKIP_PREBUILT: '1'
     steps:
       - uses: actions/checkout@v4
 

--- a/packaging/scripts/download-deps.sh
+++ b/packaging/scripts/download-deps.sh
@@ -103,6 +103,67 @@ trim_so_to_soname() {
     fi
 }
 
+# ─── 下载预编译 whisper 产物（优先路径）────────────────────────────────────
+# whisper-prebuild workflow 已把 whisper.cpp + CUDA 产物打成 tarball，上传到
+# release `whisper-deps-<WHISPER_CPP_VERSION>`。release 各 job 下载它即可，省去
+# 每个 job 装 CUDA toolkit + 源码编译（单次约 50 分钟）。
+# 仅 x86_64 提供预编译；aarch64 或显式跳过（ALTGO_WHISPER_SKIP_PREBUILT=1）时
+# 返回非 0，调用方回退源码编译。
+download_prebuilt_whisper() {
+    if [[ "${ARCH}" != "x86_64" ]]; then
+        echo "[INFO] 预编译仅提供 x86_64（当前 ${ARCH}）— 走源码编译"
+        return 1
+    fi
+    # whisper-prebuild 的 force 重建必须绕过下载，否则 fresh runner 会拉到旧产物，
+    # "强制重建"名存实亡。该 workflow 在 job 级设 ALTGO_WHISPER_SKIP_PREBUILT=1。
+    if [[ "${ALTGO_WHISPER_SKIP_PREBUILT:-0}" == "1" ]]; then
+        echo "[INFO] ALTGO_WHISPER_SKIP_PREBUILT=1 — 跳过预编译，走源码编译"
+        return 1
+    fi
+
+    local tag="whisper-deps-${WHISPER_CPP_VERSION}"
+    local asset="whisper-deps-${WHISPER_CPP_VERSION}-x86_64.tar.gz"
+    local url="https://github.com/cislunarspace/altgo/releases/download/${tag}/${asset}"
+
+    echo "[INFO] 下载预编译 whisper 产物: ${url}"
+    local tmp
+    tmp="$(mktemp)"
+    if ! curl --fail --location --progress-bar \
+        --connect-timeout 30 \
+        --max-time 600 \
+        --retry 2 \
+        --retry-delay 3 \
+        -o "${tmp}" "${url}"; then
+        rm -f "${tmp}"
+        echo "[INFO] 预编译下载失败（release 不存在或网络问题）— 回退源码编译"
+        return 1
+    fi
+
+    # tarball 内层是 bin/（见 whisper-prebuild.yml 的 tar -C target/deps -czf ... bin），
+    # 解压到 DEPS_DIR 即还原 target/deps/bin/。
+    if ! tar xzf "${tmp}" -C "${DEPS_DIR}"; then
+        rm -f "${tmp}"
+        echo "[ERROR] 预编译 tarball 解压失败 — 回退源码编译"
+        return 1
+    fi
+    rm -f "${tmp}"
+
+    # 校验 5 类产物齐全（与 whisper-prebuild.yml 的 verify 步骤一致）。
+    local ok=1
+    [[ -x "${BIN_DIR}/whisper-cli" ]] || ok=0
+    [[ -x "${BIN_DIR}/whisper-server" ]] || ok=0
+    [[ "$(find "${BIN_DIR}" -maxdepth 1 -name 'libwhisper.so*' ! -type l | wc -l)" -ge 1 ]] || ok=0
+    [[ "$(find "${BIN_DIR}" -maxdepth 1 -name 'libggml.so*' ! -type l | wc -l)" -ge 1 ]] || ok=0
+    [[ "$(find "${BIN_DIR}" -maxdepth 1 -name 'libggml-cuda.so*' ! -type l | wc -l)" -ge 1 ]] || ok=0
+    if [[ "${ok}" -ne 1 ]]; then
+        echo "[ERROR] 预编译产物校验不全 — 回退源码编译"
+        return 1
+    fi
+
+    echo "[OK] 预编译 whisper 产物就绪 (${tag})"
+    return 0
+}
+
 # ─── Build whisper-cli from source (persistent cache) ─────────────────────────
 # 使用 GitHub 源码归档 tar.gz + target/deps/whisper.cpp-src，避免 git clone 在网络差时长时间无输出/卡住。
 # 版本变化、缓存损坏或构建选项变化时重新下载/重新配置；日常仅增量 cmake build。
@@ -247,6 +308,8 @@ WHISPER_TARGET="${BIN_DIR}/whisper-cli"
 
 if [[ -f "${WHISPER_TARGET}" ]]; then
     echo "[OK] whisper-cli already exists at ${WHISPER_TARGET}"
+elif download_prebuilt_whisper; then
+    echo "[OK] whisper-cli obtained from prebuilt release"
 else
     echo "[INFO] Building whisper-cli v${WHISPER_VERSION} from source (${ARCH})..."
     build_whisper_from_source "${WHISPER_TARGET}"


### PR DESCRIPTION
## 关联

预编译优化第 2 步（第 1 步 #106 已合并：whisper-prebuild workflow + 首份 `whisper-deps-1.8.4` 产物上线）。

## 背景

release 三个 Linux job 各自装 CUDA toolkit + 源码编译 whisper（约 50 分钟/个，并行墙钟约 40-50 分钟）。`whisper-deps-1.8.4` 预编译 release 已就绪，本 PR 让 download-deps.sh 直接下载它。

## 改了什么

**download-deps.sh**：
- 新增 `download_prebuilt_whisper()`：仅 x86_64 走预编译；下载 → 解压到 `target/deps/` → 校验 5 类产物（whisper-cli / whisper-server / libwhisper.so / libggml.so / libggml-cuda.so），任一步失败回退源码编译。
- 主逻辑改三分支：本地缓存 → 预编译下载 → 源码编译。
- `ALTGO_WHISPER_SKIP_PREBUILT=1` 显式绕过下载。

**whisper-prebuild.yml**（配套）：
- job 级设 `ALTGO_WHISPER_SKIP_PREBUILT=1`：否则 force 重建会从 release 拉回旧产物而非真正重编（#106 review 规范轴 #2 指出的陷阱）。
- `force` input 改 `type: boolean`（#106 review #1）。
- 加 `concurrency` 防同一版本并发重复编译（#106 review 两轴均提）。

## 行为变化（review 规格轴指出，值得知晓）

本地 `make build`（Makefile 传 x86_64）现在也会走预编译下载：从「无 nvcc 时编 CPU-only」变为「拿 CUDA 版产物」。运行时无 NVIDIA 驱动 / 无 CUDA runtime 的机器，`libggml-cuda.so` dlopen 失败自动回退 CPU，功能等价——且让本地产物与 release 产物对齐，消除两侧差异。

## 测试

- **本地实测预编译路径**：fresh `target/deps` 下跑 `download-deps.sh x86_64`，走下载 → 解压 → 校验，25 秒完成（vs 源码编译 51 分钟），5 类产物齐全可执行。
- bash 语法检查、YAML 校验通过。
- PR CI（ci.yml 的 Check job 会跑 download-deps.sh）将真实验证下载路径。

## 后续

第 3 步：release.yml / ci.yml 去掉 `enable-cuda`（预编译已含 CUDA 产物，job 不再需要 nvcc 装 toolkit）。
