### PR TITLE
fix: 保存配置后以已校验快照重启流水线，串行化保存与重启

### DIFF
--- a/src-tauri/src/cmd.rs
+++ b/src-tauri/src/cmd.rs
@@ -19,19 +19,18 @@ use crate::{
 };
 
 /// 重启语音流水线的核心编排：
-/// 取出配置快照并校验 → 停止旧流水线 → 用 `spawn` 启动新流水线。
+/// 校验配置快照 → 停止旧流水线 → 用 `spawn` 启动新流水线。
 ///
 /// `spawn` 由调用方注入，使本函数不依赖 `AppHandle`，从而可在测试中
 /// 用 fake `PipelineHandle` 验证编排，而无需构造 Tauri app。
 async fn restart_pipeline<S>(
-    config_store: &ConfigStore,
     controller: &PipelineController,
+    cfg: Arc<crate::config::Config>,
     spawn: S,
 ) -> Result<(), String>
 where
     S: FnOnce(Arc<crate::config::Config>) -> crate::PipelineHandle,
 {
-    let cfg = Arc::new(config_store.snapshot().await);
     cfg.validate().map_err(|e| e.to_string())?;
     controller.stop().await;
     controller.start_with(|| spawn(cfg)).await
@@ -84,12 +83,15 @@ pub async fn save_config(
     controller: State<'_, PipelineController>,
     patch: ConfigPatch,
 ) -> Result<(), String> {
-    let cfg = Arc::new(config_store.apply_patch(patch).await?);
+    let update = config_store.apply_patch_for_update(patch).await?;
+    let cfg = Arc::new(update.config().clone());
     let status_arc = controller.status_arc();
-    restart_pipeline(&config_store, &controller, move |_cfg| {
+    let result = restart_pipeline(&controller, cfg, move |cfg| {
         crate::spawn_pipeline_thread(&app, cfg, status_arc)
     })
-    .await
+    .await;
+    drop(update);
+    result
 }
 
 #[tauri::command]
@@ -360,6 +362,22 @@ mod tests {
         )
     }
 
+    fn gated_stop_spawn(
+        stopping: tokio::sync::oneshot::Sender<()>,
+        release: tokio::sync::oneshot::Receiver<()>,
+    ) -> crate::PipelineHandle {
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let thread_handle = std::thread::spawn(move || {
+            let _ = stop_rx.blocking_recv();
+            let _ = stopping.send(());
+            let _ = release.blocking_recv();
+        });
+        crate::PipelineHandle {
+            stop_tx,
+            thread_handle,
+        }
+    }
+
     #[tokio::test]
     async fn restart_pipeline_stops_old_and_starts_new() {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -372,7 +390,10 @@ mod tests {
 
         // restart_pipeline 应停止旧流水线并启动新流水线。
         let (new_handle, _new_stopped) = fake_spawn();
-        let result = restart_pipeline(&store, &controller, move |_cfg| new_handle).await;
+        let result = restart_pipeline(&controller, Arc::new(store.snapshot().await), move |_cfg| {
+            new_handle
+        })
+        .await;
 
         assert!(result.is_ok());
         assert!(
@@ -380,6 +401,79 @@ mod tests {
             "old pipeline should be stopped"
         );
         assert_eq!(controller.current_status(), PipelineStatus::Idle);
+    }
+
+    #[tokio::test]
+    async fn restart_pipeline_passes_supplied_config_to_spawn() {
+        let controller = PipelineController::new();
+        let mut config = Config::default();
+        config.transcriber.language = "en".to_string();
+        let (handle, _stopped) = fake_spawn();
+        let received_language = Arc::new(Mutex::new(None));
+        let received_language_clone = Arc::clone(&received_language);
+
+        restart_pipeline(&controller, Arc::new(config), move |cfg| {
+            *received_language_clone.lock().unwrap() = Some(cfg.transcriber.language.clone());
+            handle
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            received_language.lock().unwrap().as_deref(),
+            Some("en"),
+            "spawn should receive the validated configuration snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_pipeline_keeps_its_save_config_current() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(ConfigStore::load(temp_dir.path().join("altgo.toml")));
+        let controller = PipelineController::new();
+        let (stopping_tx, mut stopping_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        controller
+            .start_with(move || gated_stop_spawn(stopping_tx, release_rx))
+            .await
+            .unwrap();
+
+        let update = store
+            .apply_patch_for_update(serde_json::from_str(r#"{"language":"en"}"#).unwrap())
+            .await
+            .unwrap();
+        let cfg = Arc::new(update.config().clone());
+        let (spawned_tx, spawned_rx) = tokio::sync::oneshot::channel();
+        let restart = restart_pipeline(&controller, cfg, move |cfg| {
+            let _ = spawned_tx.send(cfg.transcriber.language.clone());
+            fake_spawn().0
+        });
+        tokio::pin!(restart);
+
+        tokio::select! {
+            result = &mut restart => panic!("restart completed before old pipeline stopped: {result:?}"),
+            _ = &mut stopping_rx => {}
+        }
+
+        let second_store = Arc::clone(&store);
+        let second_save = tokio::spawn(async move {
+            second_store
+                .apply_patch(serde_json::from_str(r#"{"language":"ja"}"#).unwrap())
+                .await
+        });
+
+        assert!(
+            !second_save.is_finished(),
+            "another save must wait until the current pipeline restart completes"
+        );
+        release_tx.send(()).unwrap();
+
+        restart.await.unwrap();
+        drop(update);
+
+        assert_eq!(spawned_rx.await.unwrap(), "en");
+        second_save.await.unwrap().unwrap();
+        assert_eq!(store.snapshot().await.transcriber.language, "ja");
     }
 
     #[tokio::test]
@@ -394,7 +488,12 @@ mod tests {
         let store = ConfigStore::load(path);
         let controller = PipelineController::new();
 
-        let result = restart_pipeline(&store, &controller, |_cfg| unreachable!()).await;
+        let result = restart_pipeline(
+            &controller,
+            Arc::new(store.snapshot().await),
+            |_cfg| unreachable!(),
+        )
+        .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();

--- a/src-tauri/src/config_store.rs
+++ b/src-tauri/src/config_store.rs
@@ -3,7 +3,7 @@
 //! Thin persistence wrapper around `Config`. Patch logic lives in `config.rs`
 //! (`ConfigPatch::apply_to_config`), keeping config definition and mutation co-located.
 
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, MutexGuard};
 
 use crate::config::{Config, ConfigPatch};
 
@@ -12,6 +12,20 @@ use crate::config::{Config, ConfigPatch};
 pub struct ConfigStore {
     pub(crate) config: Mutex<Config>,
     config_path: std::path::PathBuf,
+}
+
+/// 已校验且已持久化的配置更新。
+///
+/// 持有锁直到调用方完成依赖本次更新的后续操作，防止其他配置更新插入。
+pub struct ConfigUpdate<'a> {
+    config: Config,
+    _guard: MutexGuard<'a, Config>,
+}
+
+impl ConfigUpdate<'_> {
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
 }
 
 impl ConfigStore {
@@ -37,11 +51,16 @@ impl ConfigStore {
         self.config.blocking_lock().clone()
     }
 
-    /// Apply a partial update, validate, persist to disk, and return the new config.
+    /// Apply a partial update, validate, persist, and keep the config lock held.
     ///
-    /// If validation fails, the in-memory config is rolled back to its pre-patch state
-    /// before returning the error, keeping memory and disk consistent.
-    pub async fn apply_patch(&self, patch: ConfigPatch) -> Result<Config, String> {
+    /// The returned update lets a caller finish a dependent operation, such as restarting
+    /// the voice pipeline, before another patch can replace the active configuration.
+    /// If validation or persistence fails, the in-memory config is rolled back before
+    /// returning the error, keeping memory and disk consistent.
+    pub async fn apply_patch_for_update(
+        &self,
+        patch: ConfigPatch,
+    ) -> Result<ConfigUpdate<'_>, String> {
         let mut cfg = self.config.lock().await;
         let original = cfg.clone();
 
@@ -52,10 +71,24 @@ impl ConfigStore {
             return Err(e.to_string());
         }
 
-        cfg.save(&self.config_path)
-            .map_err(|e| format!("save failed: {}", e))?;
+        if let Err(e) = cfg.save(&self.config_path) {
+            *cfg = original;
+            return Err(format!("save failed: {}", e));
+        }
+        let updated = cfg.clone();
 
-        Ok(cfg.clone())
+        Ok(ConfigUpdate {
+            config: updated,
+            _guard: cfg,
+        })
+    }
+
+    /// Apply a partial update, validate, persist to disk, and return the new config.
+    ///
+    /// If validation fails, the in-memory config is rolled back to its pre-patch state
+    /// before returning the error, keeping memory and disk consistent.
+    pub async fn apply_patch(&self, patch: ConfigPatch) -> Result<Config, String> {
+        Ok(self.apply_patch_for_update(patch).await?.config)
     }
 }
 
@@ -100,6 +133,18 @@ mod tests {
         let reloaded = Config::load(&path).unwrap();
         assert_eq!(reloaded.key_listener.key_name, "space");
         assert_eq!(reloaded.transcriber.language, "en");
+    }
+
+    #[tokio::test]
+    async fn apply_patch_save_failure_rolls_back_memory() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ConfigStore::load(dir.path().to_path_buf());
+        let patch: ConfigPatch = serde_json::from_str(r#"{"language":"en"}"#).unwrap();
+
+        let result = store.apply_patch(patch).await;
+
+        assert!(result.is_err());
+        assert_eq!(store.snapshot().await.transcriber.language, "zh");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 关联\nCloses #110\n\n## 改动\n- 让流水线重启直接使用本次配置更新返回的已校验快照。\n- 让配置成功写盘后继续持有 ConfigStore 锁，直到旧流水线停止、新流水线启动完成，避免并发保存造成运行配置落后。\n- 写盘失败时回滚内存配置。\n- 增加配置传递、并发保存串行化和写盘失败回滚测试。\n\n## 测试\n- cargo fmt --manifest-path=src-tauri/Cargo.toml -- --check\n- cargo clippy --manifest-path=src-tauri/Cargo.toml -- -D warnings\n- cargo test --manifest-path=src-tauri/Cargo.toml（237 个测试通过）