### PR TITLE
fix(key_capture): 回收 evtest 子进程并补充生命周期测试

### DIFF
--- a/src-tauri/src/key_capture/linux.rs
+++ b/src-tauri/src/key_capture/linux.rs
@@ -2,9 +2,9 @@
 //!
 //! 通过 `evtest` 监听 `/dev/input/event*`，阻塞等待一次按键。
 
-use std::io::BufRead;
+use std::io::{BufRead, Read};
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -54,50 +54,101 @@ fn parse_ev_key_line(line: &str) -> Option<(u16, i32)> {
 fn capture_evdev_press(timeout: Duration) -> Result<u16, String> {
     let devices = crate::key_listener::list_keyboard_devices()
         .map_err(|e| format!("keyboard devices: {}", e))?;
+    capture_evdev_press_with_devices(devices, timeout, |path| {
+        let child = Command::new("evtest")
+            .arg(path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+        Ok(Box::new(RealEvtestChild(child)) as Box<dyn EvtestChild>)
+    })
+}
+
+trait EvtestChild: Send {
+    fn take_stdout(&mut self) -> Option<Box<dyn Read + Send>>;
+    fn kill(&mut self) -> std::io::Result<()>;
+    fn wait(&mut self) -> std::io::Result<()>;
+}
+
+struct RealEvtestChild(Child);
+
+impl EvtestChild for RealEvtestChild {
+    fn take_stdout(&mut self) -> Option<Box<dyn Read + Send>> {
+        self.0
+            .stdout
+            .take()
+            .map(|stdout| Box::new(stdout) as Box<dyn Read + Send>)
+    }
+
+    fn kill(&mut self) -> std::io::Result<()> {
+        self.0.kill()
+    }
+
+    fn wait(&mut self) -> std::io::Result<()> {
+        self.0.wait().map(|_| ())
+    }
+}
+
+fn capture_evdev_press_with_devices<F>(
+    devices: Vec<PathBuf>,
+    timeout: Duration,
+    mut spawn_evtest: F,
+) -> Result<u16, String>
+where
+    F: FnMut(&std::path::Path) -> std::io::Result<Box<dyn EvtestChild>>,
+{
     if devices.is_empty() {
         return Err("未找到键盘设备（/dev/input）".into());
     }
 
     let (tx, rx) = mpsc::sync_channel::<u16>(1);
     let deadline = Instant::now() + timeout;
+    let mut children = Vec::new();
+    let mut readers = Vec::new();
 
     for device in devices {
         let tx = tx.clone();
-        let path: PathBuf = device;
-        thread::spawn(move || {
-            let mut child = match Command::new("evtest")
-                .arg(&path)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .spawn()
-            {
-                Ok(c) => c,
-                Err(_) => return,
-            };
-            let stdout = match child.stdout.take() {
-                Some(s) => s,
-                None => return,
-            };
+        let mut child = match spawn_evtest(&device) {
+            Ok(child) => child,
+            Err(_) => continue,
+        };
+        let stdout = match child.take_stdout() {
+            Some(stdout) => stdout,
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                continue;
+            }
+        };
+        children.push(child);
+        readers.push(thread::spawn(move || {
             let reader = std::io::BufReader::new(stdout);
             for line in reader.lines().map_while(Result::ok) {
                 let Some((code, value)) = parse_ev_key_line(&line) else {
                     continue;
                 };
                 if value == 1 && tx.try_send(code).is_ok() {
-                    let _ = child.kill();
-                    // kill 后须 wait 回收，避免子进程变 zombie 积累
-                    let _ = child.wait();
                     return;
                 }
             }
-        });
+        }));
     }
 
     drop(tx);
     let remaining = deadline.saturating_duration_since(Instant::now());
-    rx.recv_timeout(remaining).map_err(|_| {
+    let result = rx.recv_timeout(remaining).map_err(|_| {
         "超时：未检测到按键（请确认对 /dev/input 有读权限，如在 input 组）".to_string()
-    })
+    });
+
+    for mut child in children {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    for reader in readers {
+        let _ = reader.join();
+    }
+
+    result
 }
 
 fn capture_activation_key_blocking() -> Result<CaptureActivationResponse, String> {
@@ -134,5 +185,118 @@ mod tests {
     fn parse_ev_key_line_non_ev_key_returns_none() {
         let line = "Event: time 1234.567, type 3 (EV_ABS), code 0 (ABS_X), value 128";
         assert!(parse_ev_key_line(line).is_none());
+    }
+
+    #[test]
+    fn capture_success_reaps_evtest_child() {
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let spawned_calls = calls.clone();
+        let result = capture_evdev_press_with_devices(
+            vec![PathBuf::from("/controlled/event0")],
+            Duration::from_secs(1),
+            |_| {
+                Ok(Box::new(TestEvtestChild::new(
+                    b"Event: type 1 (EV_KEY), code 56 (KEY_LEFTALT), value 1\n".to_vec(),
+                    spawned_calls.clone(),
+                )))
+            },
+        );
+
+        assert_eq!(result.unwrap(), 56);
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![TestChildCall::Kill, TestChildCall::Wait]
+        );
+    }
+
+    #[test]
+    fn capture_timeout_reaps_evtest_child() {
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let spawned_calls = calls.clone();
+        let result = capture_evdev_press_with_devices(
+            vec![PathBuf::from("/controlled/event0")],
+            Duration::from_millis(10),
+            |_| {
+                Ok(Box::new(TestEvtestChild::new(
+                    Vec::new(),
+                    spawned_calls.clone(),
+                )))
+            },
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![TestChildCall::Kill, TestChildCall::Wait]
+        );
+    }
+
+    #[test]
+    fn capture_missing_stdout_reaps_evtest_child() {
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let spawned_calls = calls.clone();
+        let result = capture_evdev_press_with_devices(
+            vec![PathBuf::from("/controlled/event0")],
+            Duration::from_secs(1),
+            |_| {
+                Ok(Box::new(TestEvtestChild::without_stdout(
+                    spawned_calls.clone(),
+                )))
+            },
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![TestChildCall::Kill, TestChildCall::Wait]
+        );
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum TestChildCall {
+        Kill,
+        Wait,
+    }
+
+    struct TestEvtestChild {
+        stdout: Option<std::io::Cursor<Vec<u8>>>,
+        calls: std::sync::Arc<std::sync::Mutex<Vec<TestChildCall>>>,
+    }
+
+    impl TestEvtestChild {
+        fn new(
+            stdout: Vec<u8>,
+            calls: std::sync::Arc<std::sync::Mutex<Vec<TestChildCall>>>,
+        ) -> Self {
+            Self {
+                stdout: Some(std::io::Cursor::new(stdout)),
+                calls,
+            }
+        }
+
+        fn without_stdout(calls: std::sync::Arc<std::sync::Mutex<Vec<TestChildCall>>>) -> Self {
+            Self {
+                stdout: None,
+                calls,
+            }
+        }
+    }
+
+    impl EvtestChild for TestEvtestChild {
+        fn take_stdout(&mut self) -> Option<Box<dyn Read + Send>> {
+            self.stdout
+                .take()
+                .map(|stdout| Box::new(stdout) as Box<dyn Read + Send>)
+        }
+
+        fn kill(&mut self) -> std::io::Result<()> {
+            self.calls.lock().unwrap().push(TestChildCall::Kill);
+            Ok(())
+        }
+
+        fn wait(&mut self) -> std::io::Result<()> {
+            self.calls.lock().unwrap().push(TestChildCall::Wait);
+            Ok(())
+        }
     }
 }

--- a/src-tauri/src/key_capture/mod.rs
+++ b/src-tauri/src/key_capture/mod.rs
@@ -170,9 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn boxed_key_capture_trait_object() {
-        let mut capture: Box<dyn KeyCapture> = Box::new(PlatformKeyCapture::new());
-        let result = capture.capture();
-        assert!(result.is_err());
+    fn boxed_platform_key_capture_constructs() {
+        let _capture: Box<dyn KeyCapture> = Box::new(PlatformKeyCapture::new());
     }
 }


### PR DESCRIPTION
关闭 #109：Linux 激活键捕获的子进程生命周期与测试确定性。

## 改动摘要

- `key_capture/linux.rs`：捕获启动的 evtest 子进程由主线程统一持有；成功、超时、stdout 缺失三条路径均执行 `kill()` 后 `wait()` 回收，读取线程结束后才返回，避免长期运行 GUI 中残留子进程。
- `key_capture/mod.rs`：trait 冒烟测试改为仅构造平台实现，不再实际进入 12 秒真实硬件捕获流程。

## 测试

```text
cargo test --manifest-path=src-tauri/Cargo.toml --lib      237 passed; 0 failed
cargo fmt --manifest-path=src-tauri/Cargo.toml -- --check  通过
cargo clippy --manifest-path=src-tauri/Cargo.toml --all-targets -- -D warnings  通过
```

新增测试不读取真实 `/dev/input`，用可控替身断言 kill+wait 回收顺序。