### PR TITLE
fix(voice_pipeline): 修复转写完成后进度转发卡住

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,134 +1,274 @@
 # altgo
 
-语音转文字桌面工具。按住右 Alt 键说话，松开即转写，结果写入剪贴板，并显示在悬浮窗中。
+[![CI](https://github.com/cislunarspace/altgo/actions/workflows/ci.yml/badge.svg)](https://github.com/cislunarspace/altgo/actions/workflows/ci.yml)
+[![文档](https://img.shields.io/badge/docs-online-2f6feb)](https://cislunarspace.github.io/altgo/)
+[![Release](https://img.shields.io/github/v/release/cislunarspace/altgo)](https://github.com/cislunarspace/altgo/releases)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-支持 **Linux**（Ubuntu 20.04+）和 **Windows**（MSI 安装包）。不支持 macOS。
+**altgo** 是一款跨平台桌面语音转文字工具。按住触发键说话，松开后自动完成录音、转写和可选润色，结果写入系统剪贴板并显示在悬浮窗中。
 
-**在线文档**：https://cislunarspace.github.io/altgo/（源码在 `docs-site/`）
+支持 **Linux**（Ubuntu 20.04+）和 **Windows**。目前不支持 macOS。
+
+- [在线文档](https://cislunarspace.github.io/altgo/)
+- [下载 Releases](https://github.com/cislunarspace/altgo/releases)
+- [报告问题](https://github.com/cislunarspace/altgo/issues)
 
 ## 功能
 
-- 长按右 Alt 键录音，松开自动转写
-- 双击右 Alt 键进入连续录音模式，再次单击停止
-- 本地 whisper.cpp 转写，模型可在设置里下载。有 NVIDIA 显卡并安装 CUDA runtime 时自动启用 GPU 加速，否则回退 CPU。本地自动拉起常驻 whisper-server 提速，不可用时回退一次性 whisper-cli
-- 可选 LLM 润色，支持 OpenAI 兼容与 Anthropic Messages 两种协议
+- 长按右 Alt 录音，松开后自动转写
+- 双击右 Alt 进入连续录音，再次单击停止
+- 本地 `whisper.cpp` 转写，模型可在设置页下载和管理
+- 可选常驻 `whisper-server`，模型只加载一次；不可用时自动回退到 `whisper-cli`
+- 支持 OpenAI 兼容的 Whisper API 和小米 MiMo ASR 云端转写
+- 支持 OpenAI 兼容 API 与 Anthropic Messages API 的 LLM 润色
 - 结果写入剪贴板，并在悬浮窗展示，可再次复制
-- 托盘常驻，可隐藏窗口或退出
-- 转写历史保存在本地 history.json，可查看、复制、删除、清空、再次润色。历史只保存文本，不保存音频
-
-## 系统要求
-
-### Linux
-
-- 需将当前用户加入 `input` 组，否则无法读取键盘设备。加入后须重新登录
-
-  ```bash
-  sudo usermod -aG input "$USER"
-  ```
-
-- 其余依赖由安装包自动处理
-
-### Windows
-
-- 需要 WebView2 Runtime（MSI 会自动安装），使用系统默认麦克风
-- 无需额外依赖
+- 托盘常驻，可隐藏主窗口或退出应用
+- 保存本地转写历史，可查看、复制、删除、清空和再次润色
+- 只保存文本，不保存音频
 
 ## 安装
 
 ### Linux
 
-1. 到 [Releases](https://github.com/cislunarspace/altgo/releases) 下载安装包
-2. 按格式安装：
+安装前先将当前用户加入 `input` 组，否则无法读取键盘设备。执行后需要重新登录：
+
+```bash
+sudo usermod -aG input "$USER"
+```
+
+然后：
+
+1. 从 [Releases](https://github.com/cislunarspace/altgo/releases) 下载对应安装包：`.deb`、`.rpm` 或 `.flatpak`。
+2. 安装下载的包，例如：
 
    ```bash
-   sudo apt install ./altgo_*_amd64.deb     # deb
-   sudo dnf install ./altgo-*.rpm           # rpm
-   flatpak install --user ./altgo-*.flatpak # flatpak
+   sudo apt install ./altgo_*.deb
+   # 或
+   sudo dnf install ./altgo-*.rpm
+   # 或
+   flatpak install --user ./altgo-*.flatpak
    ```
 
-3. 加入 `input` 组并重新登录（见系统要求）
-4. 启动应用，在设置里完成转写模型与润色
+3. 重新登录后启动 altgo，在设置页完成转写配置。
+
+官方 Linux 安装包会捆绑 `whisper-cli`。桌面、音频、剪贴板和通知依赖由 `.deb` / `.rpm` 的包管理器声明处理；Wayland 下按键监听还会使用 `evtest`。
 
 ### Windows
 
-1. 到 [Releases](https://github.com/cislunarspace/altgo/releases) 下载 MSI
-2. 双击运行，按向导完成安装
-3. 启动应用，在设置里完成转写模型与润色
+1. 从 [Releases](https://github.com/cislunarspace/altgo/releases) 下载 `.msi` 安装包。
+2. 双击安装包并按向导完成安装。
+3. 启动 altgo，在设置页完成转写配置。
 
-## 使用
+Windows 使用全局键盘钩子和系统默认麦克风，不需要 `input` 组或额外命令行工具。MSI 会自动处理 WebView2 Runtime。
 
-启动后先在设置页完成转写模型、润色与触发键，然后：
+## 快速开始
 
-1. 长按右 Alt 录音，松开后转写（可选润色），结果进剪贴板和悬浮窗
-2. 双击右 Alt 进入连续录音，再次单击停止
-3. 在历史记录页可浏览、复制、删除、清空、再次润色
+启动应用后，在 **设置** 页完成以下配置：
 
-默认触发键是右 Alt。按它没反应时，Linux 检查是否已加入 `input` 组并重新登录，Windows 确认 altgo 窗口在前台。可用 `RUST_LOG=altgo=debug altgo` 查看日志。
+1. 选择转写引擎：本地模型、Whisper API 或 MiMo ASR。
+2. 本地模式下载并选择一个模型；云端模式填写 API Key、服务地址和模型名。
+3. 按需设置润色级别和润色服务。
+4. 确认触发键，默认是右 Alt。
+5. 点击保存。
+
+默认使用长按模式：
+
+```text
+按下右 Alt → 开始录音 → 松开右 Alt → 转写 → 润色（可选）→ 剪贴板 + 悬浮窗
+```
+
+较长的发言可以双击右 Alt 进入连续录音，再单击一次停止：
+
+```text
+双击右 Alt → 连续录音 → 单击右 Alt → 转写 → 润色（可选）→ 剪贴板 + 悬浮窗
+```
+
+历史记录默认保存在：
+
+```text
+Linux:   ~/.config/altgo/history.json
+Windows: %APPDATA%/altgo/history.json
+```
 
 ## 配置
 
-配置文件位于 `~/.config/altgo/altgo.toml`，模板见 [`configs/altgo.toml`](configs/altgo.toml)。
-
-| 变量 | 说明 |
-| ---- | ---- |
-| `ALTGO_POLISHER_API_KEY` | 覆盖润色 API 密钥 |
-| `ALTGO_TRANSCRIBER_API_KEY` | 覆盖云端转写 API 密钥 |
-| `RUST_LOG` | 日志级别，如 `altgo=debug` |
-
-## 架构
+日常使用推荐通过设置页配置。需要手动编辑时，配置文件位于：
 
 ```text
-按键事件 → 状态机 → 录音 → whisper.cpp 转写 → 可选润色 → 剪贴板 + 悬浮窗 + 历史
+Linux:   ~/.config/altgo/altgo.toml
+Windows: %APPDATA%/altgo/altgo.toml
 ```
 
-基于 Tauri，前端 React，核心逻辑 Rust。关键模块：
+完整字段说明见 [`configs/altgo.toml`](configs/altgo.toml)。在线配置说明见[配置指南](https://cislunarspace.github.io/altgo/docs/configuration)。
 
-| 模块 | 职责 |
-|------|------|
-| `state_machine` | 按键状态管理（长按 / 双击 / 连续录音） |
-| `key_listener` | 按键监听（Linux xinput / Windows WH_KEYBOARD_LL） |
-| `recorder` | 音频采集（Linux parecord / Windows cpal） |
-| `transcriber` | 转写后端：本地 whisper-server（回退 whisper-cli）、OpenAI 兼容 API、小米 MiMo 云 API |
-| `whisper_server` | 常驻 whisper-server 管理，模型常驻内存 |
-| `polisher` | OpenAI 兼容或 Anthropic 协议润色 |
-| `output` | 剪贴板写入（Linux xclip / xsel / wl-copy，Windows arboard） |
-| `history` | 本地 history.json 读写 |
-| `model` | GGML 模型下载与管理 |
-| `overlay` | 悬浮窗（状态意图与窗口操作分离） |
-| `tauri_sink` | 管道事件转 Tauri 事件与悬浮窗状态 |
-| `pipeline_controller` | 管道生命周期与状态跟踪 |
+### 转写引擎
 
-## 开发环境
+本地转写是默认方式：
 
-前置依赖：Rust stable、Node.js 18+、Tauri CLI（`cargo install tauri-cli`）。
+```toml
+[transcriber]
+engine = "local"
+model = ""              # 在设置页下载模型后选择，或填写 GGML 模型路径
+language = "zh"
+```
 
-从源码构建：
+OpenAI 兼容 Whisper API：
+
+```toml
+[transcriber]
+engine = "api"
+api_key = "sk-your-key"
+api_base_url = "https://api.openai.com"
+model = "whisper-1"
+language = "zh"
+```
+
+小米 MiMo ASR：
+
+```toml
+[transcriber]
+engine = "mimo"
+api_key = "your-api-key"
+api_base_url = "https://api.xiaomimimo.com/v1"
+language = "zh"
+```
+
+### 润色
+
+润色默认关闭。启用时需要配置协议、API 地址、模型和密钥：
+
+```toml
+[polisher]
+level = "medium"        # none / light / medium / heavy
+protocol = "openai"     # openai / anthropic
+api_key = "sk-your-key"
+api_base_url = "https://api.example.com"
+model = "your-model"
+```
+
+也可以用环境变量覆盖 API Key：
 
 ```bash
+export ALTGO_TRANSCRIBER_API_KEY="your-transcriber-key"
+export ALTGO_POLISHER_API_KEY="your-polisher-key"
+```
+
+日志级别可通过 `RUST_LOG` 调整：
+
+```bash
+RUST_LOG=altgo=debug altgo
+```
+
+## 故障排查
+
+### 按键没有反应
+
+- Linux 确认当前用户已加入 `input` 组，并已重新登录。
+- Wayland 确认 `evtest` 已安装，且当前用户能读取 `/dev/input/event*`。
+- X11 确认 `xinput` 和 `xmodmap` 可用。
+- 在设置页重新使用“按下以设置”捕获触发键。
+- 用 `RUST_LOG=altgo=debug altgo` 查看键盘监听和流水线日志。
+
+### 能录音但没有转写结果
+
+- 先确认录音结束后悬浮窗是否进入“处理中”。
+- 本地模式确认已下载模型，并且 `whisper-cli` 可用。
+- API 模式确认 API Key、服务地址和模型名正确。
+- MiMo 模式确认使用了完整地址 `https://api.xiaomimimo.com/v1`。
+- 检查日志中的 `transcription failed`、模型路径和 API 返回错误。
+
+### 没有写入剪贴板
+
+- Linux 确认 `xclip`、`xsel` 或 `wl-copy` 至少有一个可用。
+- 即使剪贴板写入失败，结果仍可在悬浮窗或历史页中复制。
+
+## 开发
+
+### 环境要求
+
+- Rust stable
+- Node.js 18+，推荐 Node.js 20+
+- Tauri CLI：`cargo install tauri-cli --version "^2" --locked`
+- Linux 或 Windows；完整 Tauri 构建需要满足 [Tauri 2 前置条件](https://tauri.app/start/prerequisites/)
+
+### Linux 构建
+
+```bash
+git clone https://github.com/cislunarspace/altgo.git
+cd altgo
 cd frontend && npm install && cd ..
 make deps-linux
 make build
 ```
 
-Windows 用 `.\build.ps1` 或 `build.cmd`。系统依赖（GTK/WebKit 等）见 [CLAUDE.md](CLAUDE.md)。
+`make build` 会准备前端依赖和 `whisper.cpp` 相关二进制，然后执行 Tauri 生产构建。只想快速运行开发版时，可以使用：
 
-常用命令：
+```bash
+cd frontend && npm install && cd ..
+cargo tauri dev
+```
 
-| 命令 | 说明 |
-| ---- | ---- |
-| `make deps-linux` | 下载 whisper 依赖到 target/deps/bin |
-| `make build` | 构建并拷贝依赖二进制到发布目录 |
-| `make install` | 安装到系统（/usr/local/bin 等） |
-| `make test` / `make fmt` / `make lint` | 测试、格式化、Clippy 检查 |
-| `cargo tauri dev` | 开发模式热重载 |
+### Windows 构建
+
+在 PowerShell 中执行：
+
+```powershell
+.\build.ps1
+```
+
+也可以使用 `build.cmd`，或直接运行 `pwsh packaging/scripts/build.ps1`。需要 Rust 的 MSVC 工具链、Node.js 和 PowerShell 7+。
+
+### 测试与检查
+
+```bash
+make test
+make fmt
+make lint
+cd frontend && npm test
+cd frontend && npm run build
+```
+
+对应的底层命令和贡献流程见 [`CONTRIBUTING.md`](CONTRIBUTING.md)。
+
+## 项目结构
+
+```text
+frontend/             React 前端与 Tauri 页面
+src-tauri/src/        Rust 核心、Tauri 命令和平台适配
+resources/prompts/    润色 prompt 模板
+configs/              配置模板
+packaging/            Linux / Windows 打包脚本
+docs-site/            面向用户的 Docusaurus 文档站
+docs/                 面向维护者的设计与计划归档
+```
+
+核心流水线：
+
+```text
+按键事件 → 状态机 → 录音 → 转写 → 润色（可选）→ 剪贴板 + 悬浮窗 + 历史
+```
+
+核心 Rust 模块包括：
+
+| 模块 | 职责 |
+| --- | --- |
+| `state_machine` | 长按、短按、双击和连续录音状态管理 |
+| `key_listener` | Linux / Windows 全局按键监听 |
+| `recorder` | Linux PulseAudio 与 Windows WASAPI 音频采集 |
+| `transcriber` | 本地 whisper.cpp、Whisper API、MiMo ASR |
+| `polisher` | OpenAI 兼容或 Anthropic 协议润色 |
+| `voice_pipeline` | 编排录音、转写、润色和输出事件 |
+| `history` | 本地历史记录读写 |
+| `overlay` | 悬浮窗状态和窗口管理 |
 
 ## 相关文档
 
-- 在线文档：https://cislunarspace.github.io/altgo/
-- [CONTRIBUTING.md](CONTRIBUTING.md)（CI / Release / GitHub Pages 维护）
-- [CLAUDE.md](CLAUDE.md)（面向 AI 与贡献者的架构速览）
-- [docs/](docs/)（设计与计划归档）
+- [在线文档](https://cislunarspace.github.io/altgo/)：快速开始、配置、使用说明、架构和 FAQ
+- [`CONTRIBUTING.md`](CONTRIBUTING.md)：开发流程、测试、CI、Release 和文档站部署
+- [`docs/README.md`](docs/README.md)：设计与计划类文档索引
+- [`CLAUDE.md`](CLAUDE.md)：面向维护者与 AI 协作者的架构速览
+- [`CHANGELOG.md`](CHANGELOG.md)：版本变更记录
 
 ## 许可证
 
-[MIT](LICENSE)
+[MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo usermod -aG input "$USER"
 
 3. 重新登录后启动 altgo，在设置页完成转写配置。
 
-官方 Linux 安装包会捆绑 `whisper-cli`。桌面、音频、剪贴板和通知依赖由 `.deb` / `.rpm` 的包管理器声明处理；Wayland 下按键监听还会使用 `evtest`。
+官方 Linux 安装包会捆绑 `whisper-cli`。`.deb` 会声明桌面、音频、剪贴板、通知和 `evtest` 等依赖；`.rpm` 会声明主要桌面和音频依赖，若使用 Wayland，请确认系统已安装 `evtest` 且当前用户能读取 `/dev/input/event*`。
 
 ### Windows
 

--- a/src-tauri/src/voice_pipeline/handlers.rs
+++ b/src-tauri/src/voice_pipeline/handlers.rs
@@ -66,10 +66,8 @@ pub async fn handle_stop_record(
         }
     });
 
-    let transcribe_result = transcriber
-        .transcribe(&wav_data, Arc::clone(&progress_cb))
-        .await;
-    drop(progress_cb);
+    let transcribe_result = transcriber.transcribe(&wav_data, progress_cb).await;
+    forwarder.abort();
     let _ = forwarder.await;
     let result = match transcribe_result {
         Ok(r) => r,
@@ -387,6 +385,72 @@ mod tests {
     // ---------------------------------------------------------------------------
     // handle_stop_record 成功与失败分支测试
     // ---------------------------------------------------------------------------
+
+    struct RetainingProgressTranscriber {
+        progress: std::sync::Mutex<Option<Arc<dyn Fn(f32) + Send + Sync>>>,
+    }
+
+    impl RetainingProgressTranscriber {
+        fn new() -> Self {
+            Self {
+                progress: std::sync::Mutex::new(None),
+            }
+        }
+    }
+
+    impl crate::transcriber::Transcriber for RetainingProgressTranscriber {
+        fn transcribe<'life0, 'life1>(
+            &'life0 self,
+            _audio: &'life1 [u8],
+            on_progress: Arc<dyn Fn(f32) + Send + Sync>,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<crate::transcriber::TranscribeResult, TranscriberError>,
+                    > + Send
+                    + 'life0,
+            >,
+        >
+        where
+            'life1: 'life0,
+        {
+            *self.progress.lock().unwrap() = Some(on_progress);
+            Box::pin(async {
+                Ok(crate::transcriber::TranscribeResult {
+                    text: String::new(),
+                    language: "zh".to_string(),
+                })
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_stop_record_does_not_wait_for_retained_progress_callback() {
+        let wav = make_test_wav();
+        let mut recorder = super::super::test_doubles::FakeRecorder::new(wav);
+        let transcriber = RetainingProgressTranscriber::new();
+        let formatter = failing_formatter();
+        let sink = super::super::test_doubles::MockSink::new();
+        let sink_arc: Arc<dyn PipelineSink> = Arc::new(sink.clone());
+
+        recorder.start_recording().unwrap();
+
+        tokio::time::timeout(
+            Duration::from_millis(200),
+            handle_stop_record(
+                &mut recorder,
+                &transcriber,
+                &formatter,
+                PolishLevel::None,
+                sink_arc,
+            ),
+        )
+        .await
+        .expect("transcription result must not wait for a retained progress callback");
+
+        assert!(transcriber.progress.lock().unwrap().is_some());
+        assert_eq!(sink.results().len(), 1);
+    }
 
     #[tokio::test]
     async fn handle_stop_record_success_chain_falls_back_to_raw_on_polish_failure() {

--- a/src-tauri/src/voice_pipeline/handlers.rs
+++ b/src-tauri/src/voice_pipeline/handlers.rs
@@ -376,8 +376,10 @@ mod tests {
     // handle_stop_record 成功与失败分支测试
     // ---------------------------------------------------------------------------
 
+    type ProgressCallback = Arc<dyn Fn(f32) + Send + Sync>;
+
     struct RetainingProgressTranscriber {
-        progress: std::sync::Mutex<Option<Arc<dyn Fn(f32) + Send + Sync>>>,
+        progress: std::sync::Mutex<Option<ProgressCallback>>,
     }
 
     impl RetainingProgressTranscriber {

--- a/src-tauri/src/voice_pipeline/handlers.rs
+++ b/src-tauri/src/voice_pipeline/handlers.rs
@@ -66,7 +66,10 @@ pub async fn handle_stop_record(
         }
     });
 
-    let transcribe_result = transcriber.transcribe(&wav_data, progress_cb).await;
+    let transcribe_result = transcriber
+        .transcribe(&wav_data, Arc::clone(&progress_cb))
+        .await;
+    drop(progress_cb);
     let _ = forwarder.await;
     let result = match transcribe_result {
         Ok(r) => r,

--- a/src-tauri/src/voice_pipeline/handlers.rs
+++ b/src-tauri/src/voice_pipeline/handlers.rs
@@ -52,23 +52,13 @@ pub async fn handle_stop_record(
 
     sink.on_progress("transcribe", None);
 
-    // Bridge the trait's Arc<dyn Fn> progress callback to the sink — the
-    // callback must own its data, so we run a small forwarder task that
-    // listens to an mpsc channel and invokes the callback.
-    let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel::<f32>();
+    // Progress callbacks are synchronous, so forward them directly to the sink.
+    let progress_sink = sink.clone();
     let progress_cb: Arc<dyn Fn(f32) + Send + Sync> = Arc::new(move |fr: f32| {
-        let _ = progress_tx.send(fr);
-    });
-    let forwarder_sink = sink.clone();
-    let forwarder = tokio::spawn(async move {
-        while let Some(fr) = progress_rx.recv().await {
-            forwarder_sink.on_progress("transcribe", Some(fr));
-        }
+        progress_sink.on_progress("transcribe", Some(fr));
     });
 
     let transcribe_result = transcriber.transcribe(&wav_data, progress_cb).await;
-    forwarder.abort();
-    let _ = forwarder.await;
     let result = match transcribe_result {
         Ok(r) => r,
         Err(e) => {
@@ -414,6 +404,7 @@ mod tests {
         where
             'life1: 'life0,
         {
+            on_progress(0.5);
             *self.progress.lock().unwrap() = Some(on_progress);
             Box::pin(async {
                 Ok(crate::transcriber::TranscribeResult {
@@ -436,7 +427,7 @@ mod tests {
         recorder.start_recording().unwrap();
 
         tokio::time::timeout(
-            Duration::from_millis(200),
+            Duration::from_secs(1),
             handle_stop_record(
                 &mut recorder,
                 &transcriber,
@@ -449,6 +440,14 @@ mod tests {
         .expect("transcription result must not wait for a retained progress callback");
 
         assert!(transcriber.progress.lock().unwrap().is_some());
+        assert_eq!(
+            sink.progress(),
+            vec![
+                ("transcribe".to_string(), None),
+                ("transcribe".to_string(), Some(0.5)),
+                ("done".to_string(), Some(1.0))
+            ]
+        );
         assert_eq!(sink.results().len(), 1);
     }
 

--- a/src-tauri/src/voice_pipeline/test_doubles.rs
+++ b/src-tauri/src/voice_pipeline/test_doubles.rs
@@ -16,6 +16,9 @@ use crate::transcriber::Transcriber;
 
 use super::sink::{PipelineSink, TranscriptionResult};
 
+type ProgressEvent = (String, Option<f32>);
+type ProgressEvents = Arc<Mutex<Vec<ProgressEvent>>>;
+
 // ---------------------------------------------------------------------------
 // KeyListener fake
 // ---------------------------------------------------------------------------
@@ -241,7 +244,7 @@ pub(super) struct MockSink {
     status_changes: Arc<Mutex<Vec<PipelineStatus>>>,
     errors: Arc<Mutex<Vec<String>>>,
     results: Arc<Mutex<Vec<TranscriptionResult>>>,
-    progress: Arc<Mutex<Vec<(String, Option<f32>)>>>,
+    progress: ProgressEvents,
 }
 
 impl MockSink {
@@ -266,7 +269,7 @@ impl MockSink {
         self.results.lock().unwrap().clone()
     }
 
-    pub(super) fn progress(&self) -> Vec<(String, Option<f32>)> {
+    pub(super) fn progress(&self) -> Vec<ProgressEvent> {
         self.progress.lock().unwrap().clone()
     }
 }

--- a/src-tauri/src/voice_pipeline/test_doubles.rs
+++ b/src-tauri/src/voice_pipeline/test_doubles.rs
@@ -241,6 +241,7 @@ pub(super) struct MockSink {
     status_changes: Arc<Mutex<Vec<PipelineStatus>>>,
     errors: Arc<Mutex<Vec<String>>>,
     results: Arc<Mutex<Vec<TranscriptionResult>>>,
+    progress: Arc<Mutex<Vec<(String, Option<f32>)>>>,
 }
 
 impl MockSink {
@@ -249,6 +250,7 @@ impl MockSink {
             status_changes: Arc::new(Mutex::new(Vec::new())),
             errors: Arc::new(Mutex::new(Vec::new())),
             results: Arc::new(Mutex::new(Vec::new())),
+            progress: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -263,6 +265,10 @@ impl MockSink {
     pub(super) fn results(&self) -> Vec<TranscriptionResult> {
         self.results.lock().unwrap().clone()
     }
+
+    pub(super) fn progress(&self) -> Vec<(String, Option<f32>)> {
+        self.progress.lock().unwrap().clone()
+    }
 }
 
 impl PipelineSink for MockSink {
@@ -275,7 +281,12 @@ impl PipelineSink for MockSink {
     fn on_transcription_result(&self, output: &TranscriptionResult) {
         self.results.lock().unwrap().push(output.clone());
     }
-    fn on_progress(&self, _: &str, _: Option<f32>) {}
+    fn on_progress(&self, phase: &str, fraction: Option<f32>) {
+        self.progress
+            .lock()
+            .unwrap()
+            .push((phase.to_string(), fraction));
+    }
     fn on_key_listener_backend(&self, _: &str) {}
 }
 


### PR DESCRIPTION
## 关联 issue

无关联 issue。

## 改动

- 转写返回后释放进度回调发送端，使进度转发任务能退出并继续结果处理。
- 重组 README，修复链接并补充安装、配置、故障排查和开发说明。

## 验证

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`
- `cargo test --manifest-path src-tauri/Cargo.toml voice_pipeline::handlers::tests -- --nocapture`
- `npx --yes markdown-link-check README.md`