### PR TITLE
chore(ci): 优化 CI 与 Release 流程

### DIFF
--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -15,4 +15,9 @@ runs:
         sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf libasound2-dev build-essential cmake gcc-aarch64-linux-gnu ${{ inputs.extra-packages }}
     - name: Install Tauri CLI
       shell: bash
-      run: cargo install tauri-cli --version "^2" --locked
+      run: |
+        # rust-cache 会恢复 ~/.cargo/bin；版本匹配时避免每个 job 重跑 cargo install。
+        if cargo tauri --version 2>/dev/null | grep -Fq '2.10.1'; then
+          exit 0
+        fi
+        cargo install tauri-cli --version "2.10.1" --locked

--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -17,8 +17,10 @@ runs:
       shell: bash
       run: |
         # rust-cache 会恢复 ~/.cargo/bin；版本匹配时避免每个 job 重跑 cargo install。
-        installed_version="$(cargo tauri --version 2>/dev/null | awk 'NR == 1 { print $2; exit }')"
-        if [[ "${installed_version}" == "2.10.1" ]]; then
-          exit 0
+        if command -v cargo-tauri >/dev/null 2>&1; then
+          installed_version="$(cargo tauri --version | awk 'NR == 1 { print $2; exit }')"
+          if [[ "${installed_version}" == "2.10.1" ]]; then
+            exit 0
+          fi
         fi
         cargo install tauri-cli --version "2.10.1" --locked

--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -17,7 +17,8 @@ runs:
       shell: bash
       run: |
         # rust-cache 会恢复 ~/.cargo/bin；版本匹配时避免每个 job 重跑 cargo install。
-        if cargo tauri --version 2>/dev/null | grep -Fq '2.10.1'; then
+        installed_version="$(cargo tauri --version 2>/dev/null | awk 'NR == 1 { print $2; exit }')"
+        if [[ "${installed_version}" == "2.10.1" ]]; then
           exit 0
         fi
         cargo install tauri-cli --version "2.10.1" --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [master]
 
+# 同一分支的新提交无需等待旧提交完成，避免重复占用双架构 runner。
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -33,9 +41,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      # Cargo workspace 在 src-tauri；默认的根目录 target/ 不存在，必须显式指定。
+      # 保留 rust-cache 默认的 job 隔离，避免 debug 测试缓存抢占 release 打包缓存。
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+          workspaces: |
+            src-tauri -> target
 
       # 系统依赖、打包用二进制、Tauri CLI 统一在 composite action 里装
       - uses: ./.github/actions/setup-linux-build
@@ -43,23 +55,27 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
         run: npm ci
         working-directory: frontend
 
+      # 前端测试、fmt 和 Clippy 不依赖目标架构，单跑一次即可；两个架构仍会
+      # 分别执行测试和实际 deb 打包，覆盖各自的编译及链接路径。
       - name: Run frontend tests
+        if: matrix.arch == 'amd64'
         run: npm test
         working-directory: frontend
 
       - name: Check formatting
+        if: matrix.arch == 'amd64'
         run: cargo fmt --manifest-path=src-tauri/Cargo.toml --all -- --check
 
       - name: Clippy
+        if: matrix.arch == 'amd64'
         run: cargo clippy --manifest-path=src-tauri/Cargo.toml --all-targets -- -D warnings
-
-      - name: Build
-        run: cargo build --release --manifest-path=src-tauri/Cargo.toml
 
       - name: Run tests
         run: cargo test --manifest-path=src-tauri/Cargo.toml --lib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,33 @@ on:
   push:
     tags: ["v*"]
 
+# 除创建 GitHub Release 外，其余 job 均只读取仓库内容。
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
-permissions:
-  contents: write
-
 jobs:
+  validate:
+    name: 校验发布元数据
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: 校验 Tag 与版本
+        run: bash packaging/scripts/validate-release.sh
+
   test:
     name: Run tests (${{ matrix.arch }})
+    needs: validate
     strategy:
       fail-fast: false
       matrix:
@@ -32,18 +50,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      # Cargo workspace 在 src-tauri；保留默认 job 隔离，避免 debug 测试缓存抢占
+      # release 打包缓存。
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}-release-test
+          key: ${{ matrix.target }}
+          workspaces: |
+            src-tauri -> target
 
       - uses: ./.github/actions/setup-linux-build
 
       - name: Run tests
         run: cargo test --manifest-path=src-tauri/Cargo.toml --lib
 
-  build-deb:
-    name: Build DEB (${{ matrix.arch }})
-    needs: [test]
+  build-linux:
+    name: 构建 Linux 软件包 (${{ matrix.arch }})
+    needs: test
     strategy:
       fail-fast: false
       matrix:
@@ -63,85 +85,45 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      # release 打包单独缓存同架构的 release 依赖编译产物。
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}-release-deb
+          key: ${{ matrix.target }}
+          workspaces: |
+            src-tauri -> target
 
       - uses: ./.github/actions/setup-linux-build
+        with:
+          extra-packages: "rpm"
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
         run: npm ci
         working-directory: frontend
 
-      - name: Build deb
-        run: cargo tauri build --bundles deb
+      # 同一架构的 deb/rpm 共享一次前端和 Rust 构建，只在 bundle 阶段分别打包。
+      - name: 构建 deb 与 rpm
+        run: cargo tauri build --bundles deb,rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload deb artifact
+      - name: 上传 Linux 软件包产物
         uses: actions/upload-artifact@v4
         with:
-          name: altgo-${{ matrix.arch }}-deb
-          path: src-tauri/target/release/bundle/deb/*.deb
-          if-no-files-found: error
-
-  build-rpm:
-    name: Build RPM (${{ matrix.arch }})
-    needs: [test]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runs-on: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-          - arch: arm64
-            runs-on: ubuntu-22.04-arm
-            target: aarch64-unknown-linux-gnu
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}-release-rpm
-
-      - uses: ./.github/actions/setup-linux-build
-        with:
-          extra-packages: 'rpm'
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install frontend dependencies
-        run: npm ci
-        working-directory: frontend
-
-      - name: Build rpm
-        run: cargo tauri build --bundles rpm
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload rpm artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: altgo-${{ matrix.arch }}-rpm
-          path: src-tauri/target/release/bundle/rpm/*.rpm
+          name: altgo-${{ matrix.arch }}-packages
+          path: |
+            src-tauri/target/release/bundle/deb/*.deb
+            src-tauri/target/release/bundle/rpm/*.rpm
           if-no-files-found: error
 
   gen-aur:
     name: Generate AUR PKGBUILD
-    needs: [build-deb]
+    needs: build-linux
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -151,24 +133,26 @@ jobs:
       - name: Download deb artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: altgo-*-deb
-          path: deb-artifact
+          pattern: altgo-*-packages
+          path: package-artifact
           merge-multiple: true
 
       - name: Get version from tag
         id: version
-        run: echo "value=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Generate PKGBUILD
         run: |
-          echo "Contents of deb-artifact:"
-          find deb-artifact -type f || true
-          AMD64_DEB=$(find deb-artifact -name '*_amd64.deb' -type f | head -1)
-          ARM64_DEB=$(find deb-artifact -name '*_arm64.deb' -type f | head -1)
-          echo "Found amd64 deb: ${AMD64_DEB}"
-          echo "Found arm64 deb: ${ARM64_DEB}"
+          mapfile -t debs < <(find package-artifact -type f -name '*.deb' | sort)
+          if [[ "${#debs[@]}" -ne 2 ]]; then
+            echo "错误：预期恰好两份 deb 产物，实际找到 ${#debs[@]} 份" >&2
+            printf '%s\n' "${debs[@]}" >&2
+            exit 1
+          fi
+          AMD64_DEB="$(find package-artifact -name '*_amd64.deb' -type f -print -quit)"
+          ARM64_DEB="$(find package-artifact -name '*_arm64.deb' -type f -print -quit)"
           if [[ -z "${AMD64_DEB}" || -z "${ARM64_DEB}" ]]; then
-            echo "ERROR: both amd64 and arm64 deb artifacts are required"
+            echo "错误：必须同时包含 amd64 与 arm64 的 deb 产物" >&2
             exit 1
           fi
           mkdir -p aur-output
@@ -187,8 +171,10 @@ jobs:
 
   release:
     name: Create Release
-    needs: [build-deb, build-rpm, gen-aur]
+    needs: [build-linux, gen-aur]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -207,13 +193,21 @@ jobs:
           path: release-assets
           merge-multiple: true
 
-      - name: List release assets
-        run: find release-assets -type f | sort
+      - name: 校验发布产物
+        run: |
+          mapfile -t debs < <(find release-assets -type f -name '*.deb' | sort)
+          mapfile -t rpms < <(find release-assets -type f -name '*.rpm' | sort)
+          if [[ "${#debs[@]}" -ne 2 || "${#rpms[@]}" -ne 2 ]]; then
+            echo "错误：预期两份 deb 和两份 rpm，实际为 ${#debs[@]} 份 deb、${#rpms[@]} 份 rpm" >&2
+            find release-assets -type f | sort >&2
+            exit 1
+          fi
+          printf '发布产物：\n%s\n' "$(find release-assets -type f | sort)"
 
       - name: Generate checksums
         run: |
           cd release-assets
-          find . -type f \( -name '*.deb' -o -name '*.rpm' \) -exec sha256sum {} \; > ../checksums.txt
+          find . -type f \( -name '*.deb' -o -name '*.rpm' \) -print0 | sort -z | xargs -0 sha256sum > ../checksums.txt
           cd ..
           cat checksums.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,5 +216,8 @@ jobs:
         with:
           body_path: release_notes.md
           files: |
-            release-assets/*
+            release-assets/**/*.deb
+            release-assets/**/*.rpm
+            release-assets/PKGBUILD
+            release-assets/.SRCINFO
             checksums.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,8 @@ type: 简短描述
 
 ## CI、Release 与 GitHub Pages
 
-- **CI**（`.github/workflows/ci.yml`）：向 `master` 推送或开 PR 时在 `amd64` 与 `arm64` 两个 Linux job 上运行 `fmt` / `clippy` / `test`，并构建 **deb**。
-- **Release**（`.github/workflows/release.yml`）：推送符合 `v*` 的 **tag**（例如 `v1.5.0`）时构建 **Linux deb / rpm**（`amd64` 与 `arm64`）及双架构 AUR PKGBUILD，生成 `checksums.txt` 并创建 GitHub Release。发版前请将 `src-tauri/Cargo.toml` / `tauri.conf.json` 中版本与 tag 对齐。
+- **CI**（`.github/workflows/ci.yml`）：向 `master` 推送或开 PR 时在 `amd64` 与 `arm64` 两个 Linux job 上运行 Rust 测试并构建 **deb**；前端测试、`fmt` 和 `clippy` 只在 `amd64` job 执行一次，因为这些检查不依赖目标架构。
+- **Release**（`.github/workflows/release.yml`）：推送符合 `v*` 的 **tag**（例如 `v1.5.0`）时，先校验 tag、Cargo、Tauri 配置、前端版本和 CHANGELOG，再构建 **Linux deb / rpm**（`amd64` 与 `arm64`）及双架构 AUR PKGBUILD，生成 `checksums.txt` 并创建 GitHub Release。发版前请将 `src-tauri/Cargo.toml`、`tauri.conf.json` 和 `frontend/package.json` 中版本与 tag 对齐。
 - **文档站**（`.github/workflows/deploy-docs.yml`）：`master` 上的 **CI 成功后**才构建 Docusaurus 并部署到 **GitHub Pages**（`workflow_run` 触发），避免 CI 失败时仍把文档发出去。首次需在仓库 **Settings → Pages** 中将 **Build and deployment** 的 Source 设为 **GitHub Actions**（勿选 branch 静态目录）。文档地址见 `docs-site/docusaurus.config.ts` 中的 `url` / `baseUrl`（例如 `https://<org>.github.io/altgo/`）。也可在 Actions 中手动 **Run workflow** 触发部署。
 
 ## 问题反馈

--- a/packaging/scripts/validate-release.sh
+++ b/packaging/scripts/validate-release.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# 校验 Release tag 与各构建入口的版本一致，并要求 CHANGELOG 有对应版本小节。
+set -euo pipefail
+
+TAG="${GITHUB_REF_NAME:?缺少 GITHUB_REF_NAME}"
+if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+    echo "Release tag 必须是 vMAJOR.MINOR.PATCH（可带预发布或构建后缀）：${TAG}" >&2
+    exit 1
+fi
+
+VERSION="${TAG#v}"
+METADATA_FILE="$(mktemp)"
+trap 'rm -f "${METADATA_FILE}"' EXIT
+
+cargo metadata \
+    --manifest-path src-tauri/Cargo.toml \
+    --no-deps \
+    --format-version 1 >"${METADATA_FILE}"
+
+CARGO_VERSION="$(node -e '
+const fs = require("fs");
+const metadata = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const packageInfo = metadata.packages.find((item) => item.name === "altgo-tauri");
+if (!packageInfo) process.exit(1);
+process.stdout.write(packageInfo.version);
+' "${METADATA_FILE}")"
+CONFIG_VERSION="$(node -e 'process.stdout.write(require("./src-tauri/tauri.conf.json").version)' )"
+FRONTEND_VERSION="$(node -e 'process.stdout.write(require("./frontend/package.json").version)' )"
+
+for entry in "Cargo=${CARGO_VERSION}" "Tauri=${CONFIG_VERSION}" "Frontend=${FRONTEND_VERSION}"; do
+    name="${entry%%=*}"
+    version="${entry#*=}"
+    if [[ "${version}" != "${VERSION}" ]]; then
+        echo "${name} 版本 ${version} 与 tag ${TAG} 不一致" >&2
+        exit 1
+    fi
+done
+
+if ! grep -Fq "## v${VERSION} " CHANGELOG.md; then
+    echo "CHANGELOG.md 缺少 v${VERSION} 版本小节" >&2
+    exit 1
+fi
+
+echo "Release ${TAG} 版本校验通过（Cargo/Tauri/Frontend/CHANGELOG）"


### PR DESCRIPTION
## 关联 issue
无关联 issue；本 PR 参考 cislunarspace/e2m2e#405，并针对 altgo 当前的 Tauri/Linux 构建结构做适配。

## 改动摘要
- 修复 `rust-cache` 的 workspace 目标，明确缓存 `src-tauri/target`，并保留测试与 release job 的缓存隔离。
- 为 CI 增加 npm 缓存和过期运行取消；架构无关的前端测试、fmt、Clippy 只执行一次。
- Release 将同一架构的 deb/rpm 合并到一次 Tauri 构建中，校验并复用双架构产物生成 AUR 与 GitHub Release。
- 新增发布前版本校验：tag、Cargo、Tauri 配置、前端版本和 CHANGELOG 必须一致；发布 job 最小化 `GITHUB_TOKEN` 权限。
- 固定 Tauri CLI 版本，缓存命中时跳过重复安装。

## 验证
- `actionlint -color=false .github/workflows/*.yml`
- `cargo fmt --manifest-path=src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path=src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path=src-tauri/Cargo.toml --lib`：200 个测试通过
- `cd frontend && npm test`：28 个测试通过
- `GITHUB_REF_NAME=v2.5.8 bash packaging/scripts/validate-release.sh`
- `git diff --check`
