### PR TITLE
docs: 重构测试文档为五层策略与派生数字（#119）

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,73 +1,131 @@
-# 测试套件现状
+# 测试策略
 
-本文档梳理 altgo 的测试套件：规模、分布、运行真实性、覆盖缺口。
-数据来自 2026-08-10 对代码库的逐模块盘点与 Linux 真实运行基线。
-面向维护者：了解现状与保持测试质量的提示从这里开始。
+本文档回答一个问题：**一个改动应该补哪层测试、用什么替身、跑什么命令验证**。
+与 [`architecture.md`](architecture.md) 配套阅读：那篇讲模块结构，这篇讲各层怎么测。
 
-## 规模
+测试分五层，从核心到外壳：
 
-共 234 个 Rust lib 测试（`cargo test --lib`），前端 vitest 30 个。无 Rust 集成测试目录，无端到端测试。
-
-Rust 测试按模块分布：
-
-| 模块 | 测试数 | 性质 |
+| 层 | 一句话职责 | 判断依据 |
 |---|---|---|
-| voice_pipeline | 27 | 端到端与 handler 行为 |
-| config | 24 | 全行为，质量好 |
-| recorder | 23 | 全行为，含 DSP |
-| overlay | 20 | manager 与 tauri 适配 |
-| audio | 17 | 全行为 |
-| model | 14 | 下载、列表、删除 |
-| polisher | 12 | OpenAI 与 Anthropic 协议、重试 |
-| state_machine | 11 | 全行为 |
-| sherpa | 3 | 模型/词表缺失报错、语言归一化 |
-| tauri_sink | 10 | 脱 Wry 后真实运行 |
-| transcriber | 0 | trait-only，经 sherpa.rs 覆盖 |
-| history | 9 | 全行为 |
-| config_store | 9 | 补丁、校验、持久化 |
-| cmd | 9 | copy_text、download_model 事件等 |
-| key_capture | 7 | 6 行为 1 冒烟 |
-| prompt_store | 6 | 模板加载 |
-| key_listener | 6 | Linux 为主 |
-| error | 5 | 错误分类 |
-| pipeline_controller | 4 | 状态机生命周期 |
-| resource | 1 | 路径解析 |
-| output | 1 | 剪贴板写入 |
+| 纯逻辑 | 不碰框架与操作系统的业务规则 | 兜底：不命中其余四层的 Rust 模块 |
+| 语音流水线 | 多模块编排契约 | 用 test_doubles 组装核心模块 |
+| Tauri 适配 | 核心与 Tauri 运行时、Linux 系统接口的接缝 | 依赖窗口/事件/命令或 X11/evdev/PulseAudio/剪贴板 |
+| 前端交互 | React 组件与表单行为 | frontend/src 下的测试 |
+| 端到端用户流程 | 真实设备上的完整用户旅程 | 当前无实现，只有缺口清单 |
 
-质量分层：绝大多数是有断言的行为测试，少量为构造/冒烟测试。测试文化整体偏行为，非凑数。
+归属规则：**一个模块的测试属于且仅属于一层，按模块归层**。同模块内测试层次混杂时，以模块的主要契约为归属。下文清单里模块名后的括号，是该模块下有测试的子模块。无测试的模块不出现在下文清单中——给它们补测试时按上表选层。
 
-前端测试：overlay.test.ts（16）、useConfigForm.test.ts（6）、
-overlay.transitions.test.tsx（4）、StatusIndicator.test.tsx（4）。
-vitest + jsdom + Testing Library。
+## 一、纯逻辑层
 
-## 运行真实性
+验证不依赖 Tauri、不依赖操作系统服务的业务规则。
 
-按 CI 实际执行分四类：
+**模块与行为**：
 
-| 类别 | 内容 | 数量 |
-|---|---|---|
-| 真实运行（Linux `check` job） | 平台无关 + 仅 Linux 测试 | 234 |
-| Linux `amd64` / `arm64` CI job | 平台无关 + Linux 测试 | 约 194 |
+- `state_machine` — 5 态 FSM 的转换、防抖与连发边界
+- `audio` — PCM 环形缓冲、WAV 编解码（含截断、非法头等异常分支）
+- `config` — TOML 加载、校验（含 SenseVoice 只接受 16kHz）、环境变量覆盖、文件权限位
+- `config_store` — `apply_patch` 的校验、持久化、失败回滚、`linux_evdev_code` 三态语义
+- `history` — 历史条目的增删改查与计数
+- `model` — 模型目录结构校验、SHA-256 校验、下载（成功、HTTP 失败、损坏检测、重试、跳过已存在）
+- `polisher` — OpenAI 兼容与 Anthropic 两种协议的请求/响应、429 与瞬时失败重试、重试耗尽
+- `sherpa` — 模型/词表缺失时的报错、语言归一化（不做真实推理）
+- `prompt_store` — prompt 模板加载、base + 各档后缀组合、缺文件降级
+- `error` — 错误的致命/可恢复分类与文案
 
-关键事实：
+**可用替身**：临时目录与文件、注入的闭包与参数、mockito 本地 HTTP 假服务器（model 下载与 polisher 协议）。本层不使用语音流水线的 test_doubles。
 
-- Linux 基线：`cargo test --lib` 234 个全绿，无跳过、无失败、无 `#[ignore]`。
-- 前端基线：vitest 30 个全绿。
-- `tauri_sink.rs` 的 10 个测试已完成脱 Wry 改造（issue #104），现在在 Linux 真实运行。
-- CI 的 `amd64` 与 `arm64` 两个 job 均跑 `cargo test --lib`。
-- `release.yml` 有独立的双架构 `test` job；deb 与 rpm 构建均 `needs: [test]`，发版前必须通过两种架构的测试。
-- fmt/clippy 已加 `--all-targets`，测试代码也会接受 clippy 编译检查。
+**执行命令**：本地按模块过滤，如 `cargo test --manifest-path=src-tauri/Cargo.toml --lib state_machine::`；CI 双架构跑全量（见「回归基线」）。
 
-## 覆盖缺口
+## 二、语音流水线层
 
-此前记录的大、中、小缺口已全部补齐，包括：
+验证编排契约：按键事件如何经状态机变成录音、转写、润色、输出动作。
 
-- 重大缺口：model 下载（成功、HTTP 失败、小于 10MB 损坏检测、3 次重试、双 base 回退、URL 覆盖）、Anthropic 协议头与响应、polisher 重试耗尽与瞬时失败恢复、cmd.rs 核心命令。
-- 中缺口：handle_stop_record 成功链路、dispatch_history_polish、PipelineContext 端到端、config_store 非原子污染。
-- 小缺口：WAV 解码异常分支、DSP 升采样/NaN/极小输入、state_machine 连发边界、overlay 失败路径、config 权限位。
+**模块与行为**：
 
-新增功能应继续遵循既有测试替身范式：FakeRecorder、FakeTranscriber、MockSink、FakeListener、RecordingOverlayWindow、mockito HTTP mock。保持可注入，就能保持可测。
+- `voice_pipeline`（handlers / context / builder）— 结果文本选择（润色优先、润色失败回退原文、空结果丢弃）、剪贴板失败仍返回结果、PipelineContext 端到端（全替身跑完按键到输出）、构建期配置校验（本地模型缺失、未知润色协议）
+- `pipeline_controller` — start/stop 生命周期：防重入、重复 start 拒绝、空 stop 空操作、不死锁
 
-## 补测试路线图
+**可用替身**：`voice_pipeline/test_doubles.rs` 里的 FakeRecorder、FakeTranscriber、MockSink、FakeListener。本层新测试一律复用这套替身，不自造第二套。
 
-本路线图已全部完成（2026-08-10）。后续新增功能按上节提示随代码一起补测试。
+**执行命令**：`cargo test --manifest-path=src-tauri/Cargo.toml --lib voice_pipeline::`（或 `pipeline_controller::`）；CI 双架构跑全量。
+
+## 三、Tauri 适配层（含 Linux 平台适配）
+
+验证两处接缝：核心与 Tauri 运行时之间，以及核心与 Linux 系统接口之间。
+
+**模块与行为**：
+
+Tauri 边界：
+
+- `tauri_sink` — 管道状态/结果到 Tauri 事件与浮窗状态的映射、事件顺序；脱 Wry 运行，不需要 Tauri 运行时
+- `cmd` — Tauri 命令的核心逻辑：restart_pipeline 的停止/启动编排、copy_text、download_model 的事件序列、polish_history_entry
+- `overlay`（manager / tauri）— 浮窗状态切换与隐藏时序、定位与缩放、各步失败容忍；xrandr 输出解析
+
+Linux 平台接缝：
+
+- `key_capture` — evtest 输出解析、子进程回收（成功/超时/无输出）
+- `key_listener` — X11 监听构造、keysym ↔ evdev 映射
+- `recorder` — PulseRecorder 构造冒烟、类型化错误
+- `output` — 剪贴板工具探测（xclip/xsel/wl-copy）
+
+**可用替身**：MockDispatch、MockOverlay、RecordingOverlayWindow（记录浮窗调用的假窗口）、注入的 spawn 闭包（key_capture 的 evtest）、mockito 本地 HTTP 假服务器（cmd 的 download_model）。**不开真实窗口，不连真实显示/音频服务**；依赖系统工具的测试写成环境容忍——有 xinput 断言 Ok、无则断言 Err；探测不到剪贴板工具也算通过。这样无显示服务器的 CI 容器与开发者机器跑出同样结果。环境过不去的测试不允许用 `#[ignore]` 藏起来。
+
+**执行命令**：按模块过滤同上，如 `cargo test --manifest-path=src-tauri/Cargo.toml --lib tauri_sink::`；CI 双架构跑全量。
+
+## 四、前端交互层
+
+验证 React 侧的组件与表单行为。
+
+**模块与行为**：
+
+- `overlay` — 浮窗阶段转换（show/replace/hide）与渲染（前端组件，与同名的 Rust `overlay` 模块不同物）
+- `useConfigForm` — 设置表单的配置归一化与保存请求体构造
+- `StatusIndicator` — 状态指示组件渲染
+
+**可用替身**：vitest + jsdom + Testing Library；Tauri IPC 一律 `vi.mock("@tauri-apps/api/core")` / `vi.mock("@tauri-apps/api/event")` 替换，不触真实后端。
+
+**执行命令**：本地 `cd frontend && npm test`；CI 只在 amd64 job 跑一次（前端测试与目标架构无关）。
+
+## 五、端到端用户流程层
+
+当前**没有任何端到端测试**。以下用户流程缺少自动化保护：
+
+1. 按住激活键 → 录音 → SenseVoice 本地转写 → 文本进剪贴板 → 浮窗各阶段切换
+2. 首次使用：设置页下载 SenseVoice 模型 → SHA-256 校验 → 转写可用
+3. 修改设置 → 保存 → 重启应用后生效（真实 IPC、真实配置文件）
+4. 历史页浏览、删除、对旧条目重新润色（真实 LLM API）
+5. deb / rpm 在 x86_64 与 aarch64 真机安装后启动并完成一次转写
+
+补这一层之前先评估代价：真实模型体积大、LLM 调用要花钱、需要显示服务器与音频设备。再决定自动化（如真实模型 + 合成 WAV 的冒烟）还是列为发版前手动回归项。决定记录在本节。
+
+## 回归基线
+
+**产品支持范围**：Linux x86_64 与 aarch64；SenseVoice 本地转写（仅接受 16kHz 单声道 16 位 PCM WAV）；可选 LLM 润色（OpenAI 兼容或 Anthropic 协议）。Windows 支持与云端转写已移除，相关测试随实现一并删除，不要回填。
+
+**CI 保护范围**：
+
+- `ci.yml` 的 check job 在 ubuntu-22.04（amd64）与 ubuntu-22.04-arm（arm64）各跑全量 `cargo test --manifest-path=src-tauri/Cargo.toml --lib`
+- 前端测试、`cargo fmt --all -- --check`、`cargo clippy --all-targets -- -D warnings`（测试代码也过编译检查）只在 amd64 job 跑一次
+- `release.yml` 的 test job 同样双架构跑 `cargo test --lib`；deb/rpm 打包（build-linux）`needs: test`，发版前必须过两种架构的测试
+
+**基线要求**：全量全绿，无 `#[ignore]`，无静默跳过。改动落在哪层，测试随代码补在哪层。若改动的风险只有端到端层能覆盖（如安装包真实启动），在 PR 里说明手动验证方式。
+
+## 派生信息：数字现查，不进文档
+
+测试数量与模块分布会随代码漂移，本文档不维护任何数字。需要时用命令现查：
+
+```bash
+# Rust 测试总数
+cargo test --manifest-path=src-tauri/Cargo.toml --lib -- --list | grep -c ': test$'
+
+# 按模块分布
+cargo test --manifest-path=src-tauri/Cargo.toml --lib -- --list | grep ': test$' | awk -F'::' '{print $1}' | sort | uniq -c
+
+# 前端（看输出末尾的 Tests 计数）
+cd frontend && npm test
+
+# 真实通过率：跑一次全量，看 test result 行
+cargo test --manifest-path=src-tauri/Cargo.toml --lib
+```
+
+覆盖率目前未统计。若日后引入覆盖率工具，把生成命令记在本节，数字本身仍不进文档。


### PR DESCRIPTION
Closes #119

## 改动摘要

按 issue #119 的 agent brief，把 `docs/testing.md` 从"现状盘点"重写为分层测试策略：

- **五层组织**：纯逻辑、语音流水线、Tauri 适配（含 Linux 平台接缝）、前端交互、端到端用户流程；每层给出要验证的行为、可用测试替身、本地与 CI 执行命令
- **数字派生化**：删除全部手工维护的测试计数（原文档写 Rust 234 / 前端 30，分诊实测已漂移为 200 / 28），改为现查命令
- **回归基线对齐当前产品**：Linux x86_64/aarch64、SenseVoice 本地转写、可选 LLM 润色；CI 保护范围逐条与 ci.yml / release.yml 核实
- **端到端层只列缺口**：5 条缺保护的用户流程，不新增 e2e 代码

改动只触及 `docs/testing.md` 一个文件。

## 测试命令及结果

- `cargo test --manifest-path=src-tauri/Cargo.toml --lib` — 200 passed, 0 failed
- `cd frontend && npm test` — 28 passed
- 文档中的派生命令（`-- --list | grep -c ': test$'` 等）已实测可用

## 评审

两轴 code-review 已跑：规格轴发现适配层替身清单漏列 mockito（`cmd.rs` 的 download_model 测试实际在用），规范轴发现 `overlay` 同名跨层未点破、「纯逻辑」排除法定义不自立，均已修正并合入本分支。