### PR TITLE
feat(overlay): 录音时悬浮窗显示实时音频电平律动条 (#132)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,10 @@
 **录音输出格式（Recorder Output Format）**
 语音管道期望录音器以固定的 16kHz、单声道、16 位 PCM WAV 字节返回音频。SenseVoice 只接受这一采样率，其他配置值会在管道启动前被拒绝。
 
+**音频电平（Audio Level）**
+录音期间由录音器从实时 PCM 音频块计算出的感知音量大小（范围 0.0 ~ 1.0）。录音线程在读取音频流时计算均方根（RMS）并通过非线性增益映射为感知电平，经 `PipelineSink::on_audio_level` 和 Tauri `audio-level` 事件以轻量节流频率（约 20~30 FPS）派发给悬浮窗，用于驱动实时音量律动波形。
+
+
 ## 按键输入
 
 **按键监听器（KeyListener）**

--- a/frontend/src/overlay.css
+++ b/frontend/src/overlay.css
@@ -95,8 +95,26 @@
 }
 
 /* ============================================
-   Recording Indicator
+   Recording Indicator & Waveform Bars
    ============================================ */
+
+.recording-bars {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 16px;
+  padding: 0 1px;
+}
+
+.recording-bar {
+  width: 3px;
+  height: 14px;
+  background: var(--color-red);
+  border-radius: var(--radius-full);
+  transform-origin: center center;
+  transition: transform 60ms ease-out;
+  will-change: transform;
+}
 
 .recording-indicator {
   position: relative;

--- a/frontend/src/overlay.transitions.test.tsx
+++ b/frontend/src/overlay.transitions.test.tsx
@@ -34,6 +34,10 @@ function emitResult(text: string) {
   act(() => handlers.get("transcription-result")!({ payload: text }));
 }
 
+function emitAudioLevel(level: number) {
+  act(() => handlers.get("audio-level")!({ payload: level }));
+}
+
 describe("Overlay 相位转换", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -94,6 +98,22 @@ describe("Overlay 相位转换", () => {
     // 容器自身的 transitionend：退出动画结束，内容清除。
     fireEvent.transitionEnd(containerEl);
     expect(container.querySelector(".island")).toBeNull();
+  });
+
+  it("recording 状态下展示 4 根动态波形条并随 audio-level 缩放", () => {
+    const { container } = render(<Overlay />);
+    emitPhase("recording");
+
+    const bars = container.querySelectorAll(".recording-bar");
+    expect(bars.length).toBe(4);
+
+    // 默认静音/无电平时保持基础 scale
+    expect((bars[0] as HTMLElement).style.transform).toBe("scaleY(0.2)");
+
+    // 收到 audio-level 事件后动态更新 scale
+    emitAudioLevel(0.8);
+    const updatedBars = container.querySelectorAll(".recording-bar");
+    expect((updatedBars[1] as HTMLElement).style.transform).not.toBe("scaleY(0.2)");
   });
 
   it("result 先于 done 到达（修复后的顺序）时正常显示结果", () => {

--- a/frontend/src/overlay.tsx
+++ b/frontend/src/overlay.tsx
@@ -89,6 +89,9 @@ export function Overlay() {
     fraction: number | null;
   } | null>(null);
 
+  // Audio level during recording (0.0 ~ 1.0).
+  const [audioLevel, setAudioLevel] = useState<number>(0);
+
   // Whether we are in an exit transition (CSS class toggle).
   const [isExiting, setIsExiting] = useState(false);
   // Crossfade（相位间切换）只做淡出，不带退出位移；exit（隐藏）才滑出。
@@ -161,10 +164,17 @@ export function Overlay() {
         setResult(null);
         setCopied(false);
         setPolishError(null);
+        setAudioLevel(0);
       } else if (newPhase === "done") {
         setTxProgress(null);
+        setAudioLevel(0);
       }
       prevPhaseRef.current = newPhase;
+    });
+
+    const unlistenAudioLevel = listen<number>("audio-level", (event) => {
+      if (!active) return;
+      setAudioLevel(event.payload ?? 0);
     });
 
     const unlistenResult = listen<string>("transcription-result", (event) => {
@@ -193,6 +203,7 @@ export function Overlay() {
       unlistenResult.then((fn) => fn());
       unlistenPolishFailed.then((fn) => fn());
       unlistenTxProgress.then((fn) => fn());
+      unlistenAudioLevel.then((fn) => fn());
     };
   }, []);
 
@@ -290,9 +301,17 @@ export function Overlay() {
       <div className="island">
         {effectivePhase === "recording" && (
           <>
-            <div className="recording-indicator">
-              <div className="recording-glow" />
-              <div className="recording-core" />
+            <div className="recording-bars" aria-hidden>
+              {[0.6, 1.0, 0.8, 0.5].map((factor, i) => {
+                const scale = Math.min(1.0, Math.max(0.2, 0.2 + audioLevel * factor * 0.8));
+                return (
+                  <div
+                    key={i}
+                    className="recording-bar"
+                    style={{ transform: `scaleY(${scale})` }}
+                  />
+                );
+              })}
             </div>
             <span className="label">{t("overlay.recording")}</span>
           </>

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -110,7 +110,29 @@ pub fn encode_wav(
     Ok(wav)
 }
 
-/// 将 16 位 PCM WAV 数据解码为 `f32` 采样（范围 [-1.0, 1.0]）。
+/// 从 16 位 PCM 字节数据中计算感知音频电平（范围 [0.0, 1.0]）。
+///
+/// 计算 PCM 采样点的均方根（RMS），并通过非线性增益映射到人耳感知的音量电平。
+pub fn calculate_audio_level(pcm_data: &[u8]) -> f32 {
+    let n_samples = pcm_data.len() / 2;
+    if n_samples == 0 {
+        return 0.0;
+    }
+
+    let mut sum_sq = 0.0f64;
+    for i in 0..n_samples {
+        let sample = i16::from_le_bytes([pcm_data[i * 2], pcm_data[i * 2 + 1]]) as f64;
+        sum_sq += sample * sample;
+    }
+
+    let rms = (sum_sq / n_samples as f64).sqrt();
+    let ratio = (rms / 32768.0) as f32;
+
+    // 感知增益曲线：放大日常语音幅度，上限截断为 1.0
+    const PERCEPTUAL_GAIN: f32 = 3.0;
+    (ratio * PERCEPTUAL_GAIN).sqrt().min(1.0)
+}
+
 pub fn decode_wav_to_f32(wav_data: &[u8]) -> Result<Vec<f32>, &'static str> {
     if wav_data.len() < 44 {
         return Err("WAV data too short");
@@ -403,5 +425,40 @@ mod tests {
 
         let decoded = decode_wav_to_f32(&wav).unwrap();
         assert_eq!(decoded.len(), 2);
+    }
+
+    #[test]
+    fn test_calculate_audio_level_silence() {
+        let pcm = vec![0u8; 1024];
+        let level = calculate_audio_level(&pcm);
+        assert_eq!(level, 0.0);
+    }
+
+    #[test]
+    fn test_calculate_audio_level_empty() {
+        assert_eq!(calculate_audio_level(&[]), 0.0);
+    }
+
+    #[test]
+    fn test_calculate_audio_level_max_amplitude() {
+        // Max positive i16 is 32767
+        let mut pcm = Vec::new();
+        for _ in 0..512 {
+            pcm.extend_from_slice(&32767i16.to_le_bytes());
+        }
+        let level = calculate_audio_level(&pcm);
+        assert!((level - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_calculate_audio_level_normal_speech_gain() {
+        // Normal speech amplitude around 2000-4000 (~0.06 - 0.12 raw ratio)
+        let mut pcm = Vec::new();
+        for _ in 0..512 {
+            pcm.extend_from_slice(&3000i16.to_le_bytes());
+        }
+        let level = calculate_audio_level(&pcm);
+        // With perceptual gain, this should produce a comfortable visible level in [0.2, 0.9]
+        assert!(level > 0.2 && level <= 1.0, "level was {}", level);
     }
 }

--- a/src-tauri/src/recorder/linux.rs
+++ b/src-tauri/src/recorder/linux.rs
@@ -5,10 +5,10 @@
 
 use crate::audio::{self, Buffer};
 use crate::error::RecorderError;
-use crate::recorder::Recorder;
+use crate::recorder::{AudioLevelCallback, Recorder};
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::thread::JoinHandle;
 
 /// PulseAudio 录音器，从默认音频源捕获 16 位 PCM 音频（16kHz 单声道）。
@@ -17,6 +17,7 @@ pub struct PulseRecorder {
     shared_buffer: Arc<Buffer>,
     recording: Arc<AtomicBool>,
     done: std::sync::Mutex<Option<JoinHandle<()>>>,
+    audio_level_cb: Arc<RwLock<Option<AudioLevelCallback>>>,
 }
 
 impl PulseRecorder {
@@ -27,6 +28,7 @@ impl PulseRecorder {
             shared_buffer: Arc::new(Buffer::new()),
             recording: Arc::new(AtomicBool::new(false)),
             done: std::sync::Mutex::new(None),
+            audio_level_cb: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -42,6 +44,7 @@ impl PulseRecorder {
         let sample_rate = self.sample_rate;
         let buffer = Arc::clone(&self.shared_buffer);
         let recording = Arc::clone(&self.recording);
+        let audio_level_cb = Arc::clone(&self.audio_level_cb);
 
         let handle = std::thread::spawn(move || {
             let child = std::process::Command::new("parecord")
@@ -73,12 +76,20 @@ impl PulseRecorder {
             };
 
             let mut reader = std::io::BufReader::new(stdout);
-            let mut chunk = [0u8; 4096];
+            let mut chunk = [0u8; 1024];
 
             while recording.load(Ordering::SeqCst) {
                 match reader.read(&mut chunk) {
                     Ok(0) => break,
-                    Ok(n) => buffer.write(&chunk[..n]),
+                    Ok(n) => {
+                        let data = &chunk[..n];
+                        buffer.write(data);
+                        if let Some(cb) = audio_level_cb.read().ok().and_then(|guard| guard.clone())
+                        {
+                            let level = audio::calculate_audio_level(data);
+                            cb(level);
+                        }
+                    }
                     Err(e) => {
                         tracing::debug!(error = %e, "read error in parecord, stopping");
                         break;
@@ -144,6 +155,12 @@ impl Recorder for PulseRecorder {
 
     fn is_recording(&self) -> bool {
         self.recording.load(Ordering::SeqCst)
+    }
+
+    fn set_audio_level_callback(&mut self, callback: Option<AudioLevelCallback>) {
+        if let Ok(mut guard) = self.audio_level_cb.write() {
+            *guard = callback;
+        }
     }
 }
 

--- a/src-tauri/src/recorder/mod.rs
+++ b/src-tauri/src/recorder/mod.rs
@@ -17,15 +17,22 @@ pub type PlatformRecorder = PulseRecorder;
 #[cfg(target_os = "windows")]
 pub type PlatformRecorder = WindowsRecorder;
 
+use std::sync::Arc;
+
 pub use crate::error::RecorderError;
 
 /// SenseVoice 的固定输入采样率（Hz）。
 pub const SAMPLE_RATE: u32 = 16_000;
 
+/// 实时音频电平回调函数类型。
+pub type AudioLevelCallback = Arc<dyn Fn(f32) + Send + Sync>;
+
 pub trait Recorder: Send {
     fn start_recording(&mut self) -> Result<(), RecorderError>;
     fn stop_recording(&self) -> Result<Vec<u8>, RecorderError>;
     fn is_recording(&self) -> bool;
+    /// 注册录音时的实时音频电平回调。
+    fn set_audio_level_callback(&mut self, _callback: Option<AudioLevelCallback>) {}
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/src-tauri/src/recorder/windows.rs
+++ b/src-tauri/src/recorder/windows.rs
@@ -5,10 +5,10 @@
 
 use crate::audio::{self, Buffer};
 use crate::error::RecorderError;
-use crate::recorder::Recorder;
+use crate::recorder::{AudioLevelCallback, Recorder};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 /// cpal 的 `Stream` 在 Windows 上不是 `Send`（内部持有原生指针），
 /// 但 `Recorder` 要求跨线程。这里显式声明发送安全性：WASAPI 流的
@@ -23,6 +23,7 @@ pub struct WindowsRecorder {
     recording: Arc<AtomicBool>,
     // Stream 必须保持存活才有数据；stop 时 drop。
     stream: Mutex<Option<SendStream>>,
+    audio_level_cb: Arc<RwLock<Option<AudioLevelCallback>>>,
 }
 
 impl WindowsRecorder {
@@ -32,6 +33,7 @@ impl WindowsRecorder {
             shared_buffer: Arc::new(Buffer::new()),
             recording: Arc::new(AtomicBool::new(false)),
             stream: Mutex::new(None),
+            audio_level_cb: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -57,6 +59,7 @@ impl WindowsRecorder {
 
         let buffer = Arc::clone(&self.shared_buffer);
         let recording = Arc::clone(&self.recording);
+        let audio_level_cb = Arc::clone(&self.audio_level_cb);
         let sample_rate = self.sample_rate;
 
         type PcmCallback = Box<dyn FnMut(&[f32], &cpal::InputCallbackInfo) + Send>;
@@ -64,21 +67,29 @@ impl WindowsRecorder {
         fn make_callback(
             buffer: Arc<Buffer>,
             recording: Arc<AtomicBool>,
+            audio_level_cb: Arc<RwLock<Option<AudioLevelCallback>>>,
             dst_rate: u32,
         ) -> impl Fn(u32, u16) -> PcmCallback {
             move |src_rate: u32, channels: u16| {
                 let buffer = Arc::clone(&buffer);
                 let recording = Arc::clone(&recording);
+                let audio_level_cb = Arc::clone(&audio_level_cb);
                 Box::new(move |data: &[f32], _info: &cpal::InputCallbackInfo| {
                     if !recording.load(Ordering::SeqCst) {
                         return;
                     }
-                    append_pcm(&buffer, data, src_rate, channels, dst_rate);
+                    let pcm = append_pcm(&buffer, data, src_rate, channels, dst_rate);
+                    if let Some(cb) = audio_level_cb.read().ok().and_then(|guard| guard.clone()) {
+                        if !pcm.is_empty() {
+                            let level = audio::calculate_audio_level(&pcm);
+                            cb(level);
+                        }
+                    }
                 })
             }
         }
 
-        let make_callback = make_callback(buffer, recording, sample_rate);
+        let make_callback = make_callback(buffer, recording, audio_level_cb, sample_rate);
         let stream = build_stream(&device, &target_config, make_callback(self.sample_rate, 1))
             .or_else(|target_err| {
                 tracing::warn!(error = %target_err, "设备拒绝 16kHz 单声道，回退默认格式");
@@ -133,10 +144,16 @@ fn build_stream(
 }
 
 /// 把 f32 帧转换为 s16le PCM 追加到 `buffer`：先按声道平均混成单声道，
-/// 源/目标采样率不同时做线性插值重采样（语音识别够用）。
-fn append_pcm(buffer: &Buffer, data: &[f32], src_rate: u32, channels: u16, dst_rate: u32) {
+/// 源/目标采样率不同时做线性插值重采样（语音识别够用），返回追加的 PCM 数据。
+fn append_pcm(
+    buffer: &Buffer,
+    data: &[f32],
+    src_rate: u32,
+    channels: u16,
+    dst_rate: u32,
+) -> Vec<u8> {
     if channels == 0 || data.len() < channels as usize {
-        return;
+        return Vec::new();
     }
     let frames: Vec<f32> = data
         .chunks(channels as usize)
@@ -155,6 +172,7 @@ fn append_pcm(buffer: &Buffer, data: &[f32], src_rate: u32, channels: u16, dst_r
         pos += step;
     }
     buffer.write(&pcm);
+    pcm
 }
 
 impl Recorder for WindowsRecorder {
@@ -168,6 +186,12 @@ impl Recorder for WindowsRecorder {
 
     fn is_recording(&self) -> bool {
         self.recording.load(Ordering::SeqCst)
+    }
+
+    fn set_audio_level_callback(&mut self, callback: Option<AudioLevelCallback>) {
+        if let Ok(mut guard) = self.audio_level_cb.write() {
+            *guard = callback;
+        }
     }
 }
 

--- a/src-tauri/src/tauri_sink.rs
+++ b/src-tauri/src/tauri_sink.rs
@@ -30,6 +30,7 @@ pub trait PipelineEventEmitter: Send + Sync + 'static {
     fn emit_transcription_result(&self, text: &str);
     fn emit_polish_failed(&self, message: &str);
     fn emit_transcription_progress(&self, phase: &str, fraction: Option<f32>);
+    fn emit_audio_level(&self, level: f32);
     fn emit_key_listener_backend(&self, backend: &str);
     fn emit_history_updated(&self);
 }
@@ -67,6 +68,10 @@ impl PipelineEventEmitter for TauriEventEmitter {
             "transcription-progress",
             serde_json::json!({ "phase": phase, "fraction": fraction }),
         );
+    }
+
+    fn emit_audio_level(&self, level: f32) {
+        let _ = self.app.emit("audio-level", level);
     }
 
     fn emit_key_listener_backend(&self, backend: &str) {
@@ -192,6 +197,10 @@ impl PipelineSink for TauriPipelineSink {
         self.emitter.emit_transcription_progress(phase, fraction);
     }
 
+    fn on_audio_level(&self, level: f32) {
+        self.emitter.emit_audio_level(level);
+    }
+
     fn on_key_listener_backend(&self, backend: &str) {
         self.emitter.emit_key_listener_backend(backend);
     }
@@ -261,6 +270,7 @@ mod tests {
             phase: String,
             fraction: Option<f32>,
         },
+        AudioLevel(f32),
         KeyListenerBackend(String),
         HistoryUpdated,
     }
@@ -319,6 +329,13 @@ mod tests {
                     phase: phase.into(),
                     fraction,
                 });
+        }
+
+        fn emit_audio_level(&self, level: f32) {
+            self.events
+                .lock()
+                .unwrap()
+                .push(EmittedEvent::AudioLevel(level));
         }
 
         fn emit_key_listener_backend(&self, backend: &str) {
@@ -583,6 +600,21 @@ mod tests {
     // -----------------------------------------------------------------------
     // on_progress 测试
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn on_audio_level_emits_audio_level() {
+        let fx = make_fixture(true, None);
+        fx.sink.on_audio_level(0.42);
+        fx.sink.on_audio_level(0.0);
+
+        assert_eq!(
+            fx.emitter.recorded_events(),
+            vec![
+                EmittedEvent::AudioLevel(0.42),
+                EmittedEvent::AudioLevel(0.0),
+            ]
+        );
+    }
 
     #[test]
     fn on_progress_emits_progress() {

--- a/src-tauri/src/voice_pipeline/context.rs
+++ b/src-tauri/src/voice_pipeline/context.rs
@@ -36,6 +36,12 @@ impl PipelineContext {
         // async task lifecycle (and so progress forwarders can hold it).
         let sink: Arc<dyn PipelineSink> = Arc::new(sink);
 
+        // 为录音器配置音频电平回调，把实时计算的 RMS 电平推入 sink
+        let level_sink = sink.clone();
+        recorder.set_audio_level_callback(Some(Arc::new(move |level: f32| {
+            level_sink.on_audio_level(level);
+        })));
+
         let mut listener: Box<dyn KeyListener> = match self.listener.lock().unwrap().take() {
             Some(l) => l,
             None => {

--- a/src-tauri/src/voice_pipeline/sink.rs
+++ b/src-tauri/src/voice_pipeline/sink.rs
@@ -36,6 +36,9 @@ pub trait PipelineSink: Send + Sync + 'static {
 
     /// 按键监听后端已启动（如 `"xinput"` / `"evtest"`）。
     fn on_key_listener_backend(&self, backend: &str);
+
+    /// 实时感知音频电平更新（0.0 ~ 1.0）。
+    fn on_audio_level(&self, _level: f32) {}
 }
 
 /// 派发结果。

--- a/src-tauri/src/voice_pipeline/test_doubles.rs
+++ b/src-tauri/src/voice_pipeline/test_doubles.rs
@@ -81,6 +81,7 @@ pub(super) struct FakeRecorder {
     pub(super) start_count: std::sync::atomic::AtomicUsize,
     pub(super) stop_count: std::sync::atomic::AtomicUsize,
     stop_error: Mutex<Option<crate::error::RecorderError>>,
+    audio_level_cb: Mutex<Option<Arc<dyn Fn(f32) + Send + Sync>>>,
 }
 
 impl FakeRecorder {
@@ -91,6 +92,7 @@ impl FakeRecorder {
             start_count: std::sync::atomic::AtomicUsize::new(0),
             stop_count: std::sync::atomic::AtomicUsize::new(0),
             stop_error: Mutex::new(None),
+            audio_level_cb: Mutex::new(None),
         }
     }
 
@@ -101,6 +103,7 @@ impl FakeRecorder {
             start_count: std::sync::atomic::AtomicUsize::new(0),
             stop_count: std::sync::atomic::AtomicUsize::new(0),
             stop_error: Mutex::new(Some(error)),
+            audio_level_cb: Mutex::new(None),
         }
     }
 
@@ -134,6 +137,10 @@ impl Recorder for FakeRecorder {
     fn is_recording(&self) -> bool {
         self.recording.load(std::sync::atomic::Ordering::SeqCst)
     }
+
+    fn set_audio_level_callback(&mut self, callback: Option<Arc<dyn Fn(f32) + Send + Sync>>) {
+        *self.audio_level_cb.lock().unwrap() = callback;
+    }
 }
 
 impl Recorder for std::sync::Arc<FakeRecorder> {
@@ -146,6 +153,10 @@ impl Recorder for std::sync::Arc<FakeRecorder> {
     }
     fn is_recording(&self) -> bool {
         (**self).is_recording()
+    }
+    fn set_audio_level_callback(&mut self, callback: Option<Arc<dyn Fn(f32) + Send + Sync>>) {
+        let ptr: *mut FakeRecorder = Arc::as_ptr(self) as *mut _;
+        unsafe { (*ptr).set_audio_level_callback(callback) }
     }
 }
 

--- a/src-tauri/src/voice_pipeline/test_doubles.rs
+++ b/src-tauri/src/voice_pipeline/test_doubles.rs
@@ -11,7 +11,7 @@ use crate::error::{KeyListenerError, OutputError};
 use crate::key_listener::{KeyEvent, KeyListener};
 use crate::output::Output;
 use crate::pipeline_controller::PipelineStatus;
-use crate::recorder::Recorder;
+use crate::recorder::{AudioLevelCallback, Recorder};
 use crate::transcriber::Transcriber;
 
 use super::sink::{PipelineSink, TranscriptionResult};
@@ -81,7 +81,7 @@ pub(super) struct FakeRecorder {
     pub(super) start_count: std::sync::atomic::AtomicUsize,
     pub(super) stop_count: std::sync::atomic::AtomicUsize,
     stop_error: Mutex<Option<crate::error::RecorderError>>,
-    audio_level_cb: Mutex<Option<Arc<dyn Fn(f32) + Send + Sync>>>,
+    audio_level_cb: Mutex<Option<AudioLevelCallback>>,
 }
 
 impl FakeRecorder {
@@ -138,7 +138,7 @@ impl Recorder for FakeRecorder {
         self.recording.load(std::sync::atomic::Ordering::SeqCst)
     }
 
-    fn set_audio_level_callback(&mut self, callback: Option<Arc<dyn Fn(f32) + Send + Sync>>) {
+    fn set_audio_level_callback(&mut self, callback: Option<AudioLevelCallback>) {
         *self.audio_level_cb.lock().unwrap() = callback;
     }
 }
@@ -154,7 +154,7 @@ impl Recorder for std::sync::Arc<FakeRecorder> {
     fn is_recording(&self) -> bool {
         (**self).is_recording()
     }
-    fn set_audio_level_callback(&mut self, callback: Option<Arc<dyn Fn(f32) + Send + Sync>>) {
+    fn set_audio_level_callback(&mut self, callback: Option<AudioLevelCallback>) {
         let ptr: *mut FakeRecorder = Arc::as_ptr(self) as *mut _;
         unsafe { (*ptr).set_audio_level_callback(callback) }
     }


### PR DESCRIPTION
## 关联 Issue
- 解决 #132

## 改动摘要
1. **音频电平计算 (`audio.rs`)**：
   - 实现 `calculate_audio_level`，基于 16-bit PCM 采样计算 RMS 振幅，配合感知增益曲线映射到 `0.0 ~ 1.0`。
2. **流水线与事件集成 (`Recorder`, `voice_pipeline`, `tauri_sink`)**：
   - 录音器读取 PCM 音频流时实时计算感知电平，通过 `PipelineSink::on_audio_level` 和 `PipelineEventEmitter::emit_audio_level` 向悬浮窗派发 Tauri `"audio-level"` 事件。
3. **悬浮窗 UI 与波形律动 (`overlay.tsx`, `overlay.css`)**：
   - 录音（`recording`）阶段将原来的静态圆点替换为 4 根圆角竖条，随实时电平通过 `transform: scaleY` 平滑律动跳动。
   - 状态切换时自动清理状态并平滑淡入淡出。

## 验证
- Rust 单元测试与集成测试：228 个测试全部通过 (`cargo test`)
- 静态检查与格式化：`cargo clippy -- -D warnings` 与 `cargo fmt -- --check` 通过
- 前端测试与构建：Vitest 39 个测试全部通过 (`npm test`)，`npm run build` 成功