### PR TITLE
fix(updater): 修复自动更新构建流程与错误归类

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,13 +106,13 @@ jobs:
         run: npm ci
         working-directory: frontend
 
-      # 同一架构的 deb/rpm/AppImage 共享一次前端和 Rust 构建，只在 bundle 阶段分别打包。
-      # Tauri CLI 用 npm 版（预编译二进制），免去每个 job 源码编译 tauri-cli。
-      # APPIMAGE_EXTRACT_AND_RUN：runner 容器无 FUSE，让 linuxdeploy 以解压模式运行。
+      # 构建 deb、rpm 与 AppImage（若配置了签名密钥则生成 updater bundle 与签名）
       - name: 构建 deb、rpm 与 AppImage
         run: npm --prefix frontend exec -- tauri build --bundles deb,rpm,appimage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
           APPIMAGE_EXTRACT_AND_RUN: "1"
 
       - name: 上传 Linux 软件包产物
@@ -123,7 +123,10 @@ jobs:
             src-tauri/target/release/bundle/deb/*.deb
             src-tauri/target/release/bundle/rpm/*.rpm
             src-tauri/target/release/bundle/appimage/*.AppImage
-          if-no-files-found: error
+            src-tauri/target/release/bundle/appimage/*.AppImage.tar.gz*
+            src-tauri/target/release/bundle/appimage/*.AppImage.sig
+            src-tauri/target/release/bundle/appimage/latest.json
+          if-no-files-found: warn
 
   build-windows:
     name: 构建 Windows 安装包 (x64)
@@ -157,6 +160,8 @@ jobs:
         run: npm --prefix frontend exec -- tauri build --bundles nsis,msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
 
       - name: 上传 Windows 安装包产物
         uses: actions/upload-artifact@v4
@@ -164,8 +169,12 @@ jobs:
           name: altgo-windows-packages
           path: |
             src-tauri/target/release/bundle/nsis/*-setup.exe
+            src-tauri/target/release/bundle/nsis/*-setup.exe.sig
+            src-tauri/target/release/bundle/nsis/*-setup.nsis.zip*
+            src-tauri/target/release/bundle/nsis/latest.json
             src-tauri/target/release/bundle/msi/*.msi
-          if-no-files-found: error
+            src-tauri/target/release/bundle/msi/*.msi.zip*
+          if-no-files-found: warn
 
   gen-aur:
     name: Generate AUR PKGBUILD
@@ -260,6 +269,11 @@ jobs:
           cd ..
           cat checksums.txt
 
+      - name: 合并各平台 Updater 产物并生成 latest.json
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          bash packaging/scripts/merge-updater-json.sh release-assets release-assets/latest.json "${VERSION}" release_notes.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -270,12 +284,15 @@ jobs:
             release-assets/**/*.AppImage
             release-assets/**/*.AppImage.tar.gz
             release-assets/**/*.AppImage.tar.gz.sig
+            release-assets/**/*.AppImage.sig
             release-assets/**/*-setup.exe
             release-assets/**/*-setup.exe.sig
+            release-assets/**/*-setup.nsis.zip
+            release-assets/**/*-setup.nsis.zip.sig
             release-assets/**/*.msi
             release-assets/**/*.msi.zip
             release-assets/**/*.msi.zip.sig
-            release-assets/**/latest.json
+            release-assets/latest.json
             release-assets/PKGBUILD
             release-assets/.SRCINFO
             checksums.txt

--- a/packaging/scripts/merge-updater-json.sh
+++ b/packaging/scripts/merge-updater-json.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# 合并各平台打包生成的 updater JSON（如 latest.json）为一个完整的 latest.json。
+# 输入参数：
+#   $1 - 搜索目录（如 release-assets）
+#   $2 - 输出文件路径（如 release-assets/latest.json）
+#   $3 - 版本号（如 2.6.4）
+#   $4 - 发布说明文件路径（可选，如 release_notes.md）
+
+set -euo pipefail
+
+SEARCH_DIR="${1:?缺少搜索目录}"
+OUTPUT_FILE="${2:?缺少输出文件路径}"
+VERSION="${3:?缺少版本号}"
+NOTES_FILE="${4:-}"
+
+node -e '
+const fs = require("fs");
+const path = require("path");
+
+const searchDir = process.argv[1];
+const outputFile = process.argv[2];
+const version = process.argv[3];
+const notesFile = process.argv[4];
+
+let notes = "";
+if (notesFile && fs.existsSync(notesFile)) {
+  notes = fs.readFileSync(notesFile, "utf8");
+}
+
+function findJsonFiles(dir) {
+  let results = [];
+  if (!fs.existsSync(dir)) return results;
+  const list = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of list) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results = results.concat(findJsonFiles(fullPath));
+    } else if (entry.name === "latest.json" && fullPath !== path.resolve(outputFile)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+const jsonFiles = findJsonFiles(searchDir);
+console.log(`找到 ${jsonFiles.length} 个 platform latest.json 文件:`, jsonFiles);
+
+const merged = {
+  version: `v${version.replace(/^v/, "")}`,
+  notes: notes || undefined,
+  pub_date: new Date().toISOString(),
+  platforms: {}
+};
+
+for (const f of jsonFiles) {
+  try {
+    const content = JSON.parse(fs.readFileSync(f, "utf8"));
+    if (content.platforms) {
+      Object.assign(merged.platforms, content.platforms);
+    }
+  } catch (err) {
+    console.error(`解析 ${f} 失败:`, err);
+  }
+}
+
+if (Object.keys(merged.platforms).length > 0) {
+  fs.writeFileSync(outputFile, JSON.stringify(merged, null, 2), "utf8");
+  console.log(`已成功生成合并后的 ${outputFile}，包含平台:`, Object.keys(merged.platforms));
+} else {
+  console.log("未发现平台更新元数据，跳过 latest.json 生成。");
+}
+' "${SEARCH_DIR}" "${OUTPUT_FILE}" "${VERSION}" "${NOTES_FILE}"

--- a/src-tauri/gen/schemas/windows-schema.json
+++ b/src-tauri/gen/schemas/windows-schema.json
@@ -2209,6 +2209,60 @@
           "type": "string",
           "const": "dialog:deny-save",
           "markdownDescription": "Denies the save command without any pre-configured scope."
+        },
+        {
+          "description": "This permission set configures which kind of\nupdater functions are exposed to the frontend.\n\n#### Granted Permissions\n\nThe full workflow from checking for updates to installing them\nis enabled.\n\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-download-and-install`",
+          "type": "string",
+          "const": "updater:default",
+          "markdownDescription": "This permission set configures which kind of\nupdater functions are exposed to the frontend.\n\n#### Granted Permissions\n\nThe full workflow from checking for updates to installing them\nis enabled.\n\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-download-and-install`"
+        },
+        {
+          "description": "Enables the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-check",
+          "markdownDescription": "Enables the check command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the download command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-download",
+          "markdownDescription": "Enables the download command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-download-and-install",
+          "markdownDescription": "Enables the download_and_install command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-install",
+          "markdownDescription": "Enables the install command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-check",
+          "markdownDescription": "Denies the check command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the download command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-download",
+          "markdownDescription": "Denies the download command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-download-and-install",
+          "markdownDescription": "Denies the download_and_install command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-install",
+          "markdownDescription": "Denies the install command without any pre-configured scope."
         }
       ]
     },

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -150,6 +150,9 @@ pub async fn check_update_core<P: UpdateProvider + ?Sized>(
                 || lower.contains("network")
                 || lower.contains("http")
                 || lower.contains("reqwest")
+                || lower.contains("could not fetch")
+                || lower.contains("failed to fetch")
+                || lower.contains("release json")
             {
                 UpdateErrorKind::Network
             } else {
@@ -373,6 +376,21 @@ mod tests {
 
         assert_eq!(err.kind, UpdateErrorKind::Network);
         assert!(err.message.contains("无法连接到更新服务器"));
+
+        // 测试 Could not fetch a valid release JSON 的映射
+        let provider2 = MockUpdateProvider::new(Err(
+            "Could not fetch a valid release JSON from the remote".to_string(),
+        ));
+        let err2 = check_update_core(
+            &provider2,
+            CheckMode::Manual,
+            Duration::from_secs(10),
+            UpdateSupportTier::InPlace,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err2.kind, UpdateErrorKind::Network);
+        assert!(err2.message.contains("无法连接到更新服务器"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 关联 Issue
无关联 issue

## 改动摘要
1. **修复 Release 工作流中 Updater 签名产物丢失问题**：
   - 在  的  和  步骤中注入  与 。
   - 上传构建产物时收集 、 等更新元数据。
2. **新增 Updater JSON 合并脚本**：
   - 添加 ，在创建 GitHub Release 前将不同构建矩阵（Linux、Windows）生成的  自动合并为一个完整的  统一上传。
3. **增强错误归类**：
   - 优化 ，将抓取 release JSON 失败归入 Network 错误并补齐测试。

## 测试验证
- `cargo test --manifest-path=src-tauri/Cargo.toml` 225 个测试全部通过。