### PR TITLE
build: 升级 sherpa-onnx 1.13.6，支持 Windows arm64，新增 winget/Scoop 清单

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
         run: |
           mkdir -p src-tauri/target/sherpa-onnx-prebuilt
           ARCH="${{ matrix.arch == 'amd64' && 'x64' || 'aarch64' }}"
-          ARCHIVE="sherpa-onnx-v1.13.5-linux-${ARCH}-static-lib.tar.bz2"
-          URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.5/${ARCHIVE}"
+          ARCHIVE="sherpa-onnx-v1.13.6-linux-${ARCH}-static-lib.tar.bz2"
+          URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/${ARCHIVE}"
           curl -fSL -o "src-tauri/target/sherpa-onnx-prebuilt/${ARCHIVE}" "${URL}"
           tar -xjf "src-tauri/target/sherpa-onnx-prebuilt/${ARCHIVE}" -C src-tauri/target/sherpa-onnx-prebuilt/
 
@@ -101,14 +101,27 @@ jobs:
   check-windows:
     name: Check (windows)
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            target: x86_64-pc-windows-msvc
+            sherpa-archive: sherpa-onnx-v1.13.6-win-x64-static-MT-Release-lib.tar.bz2
+          - arch: arm64
+            target: aarch64-pc-windows-msvc
+            sherpa-archive: sherpa-onnx-v1.13.6-win-arm64-static-MT-Release-lib.tar.bz2
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
+          key: ${{ matrix.target }}
           workspaces: |
             src-tauri -> target
 
@@ -116,8 +129,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p src-tauri/target/sherpa-onnx-prebuilt
-          ARCHIVE="sherpa-onnx-v1.13.5-win-x64-static-MT-Release-lib.tar.bz2"
-          URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.5/${ARCHIVE}"
+          ARCHIVE="${{ matrix.sherpa-archive }}"
+          URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/${ARCHIVE}"
           curl -fSL -o "src-tauri/target/sherpa-onnx-prebuilt/${ARCHIVE}" "${URL}"
           tar -xjf "src-tauri/target/sherpa-onnx-prebuilt/${ARCHIVE}" -C src-tauri/target/sherpa-onnx-prebuilt/
 
@@ -132,9 +145,15 @@ jobs:
         working-directory: frontend
 
       - name: Run tests
+        if: matrix.arch == 'x64'
         run: cargo test --manifest-path=src-tauri/Cargo.toml --lib
 
+      # arm64 在 x64 runner 上交叉编译，只能验证编译（无法执行 arm64 测试二进制）
+      - name: Check compile (arm64)
+        if: matrix.arch == 'arm64'
+        run: cargo check --manifest-path=src-tauri/Cargo.toml --target ${{ matrix.target }}
+
       - name: Build Tauri GUI
-        run: npm --prefix frontend exec -- tauri build --bundles nsis
+        run: npm --prefix frontend exec -- tauri build --target ${{ matrix.target }} --bundles nsis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,18 @@ jobs:
           if-no-files-found: warn
 
   build-windows:
-    name: 构建 Windows 安装包 (x64)
+    name: 构建 Windows 安装包 (${{ matrix.arch }})
     needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            target: x86_64-pc-windows-msvc
+            sherpa-archive: sherpa-onnx-v1.13.6-win-x64-static-MT-Release-lib.tar.bz2
+          - arch: arm64
+            target: aarch64-pc-windows-msvc
+            sherpa-archive: sherpa-onnx-v1.13.6-win-arm64-static-MT-Release-lib.tar.bz2
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -138,10 +148,22 @@ jobs:
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
+          key: ${{ matrix.target }}
           workspaces: |
             src-tauri -> target
+
+      - name: Preload sherpa-onnx prebuilt libs
+        shell: bash
+        run: |
+          mkdir -p src-tauri/target/sherpa-onnx-prebuilt
+          ARCHIVE="${{ matrix.sherpa-archive }}"
+          URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/${ARCHIVE}"
+          curl -fSL -o "src-tauri/target/sherpa-onnx-prebuilt/${ARCHIVE}" "${URL}"
+          tar -xjf "src-tauri/target/sherpa-onnx-prebuilt/${ARCHIVE}" -C src-tauri/target/sherpa-onnx-prebuilt/
 
       - uses: actions/setup-node@v4
         with:
@@ -154,10 +176,16 @@ jobs:
         working-directory: frontend
 
       - name: Run tests
+        if: matrix.arch == 'x64'
         run: cargo test --manifest-path=src-tauri/Cargo.toml --lib
 
+      # arm64 在 x64 runner 上交叉编译，只能验证编译（无法执行 arm64 测试二进制）
+      - name: Check compile (arm64)
+        if: matrix.arch == 'arm64'
+        run: cargo check --manifest-path=src-tauri/Cargo.toml --target ${{ matrix.target }}
+
       - name: 构建 NSIS 安装包与 MSI
-        run: npm --prefix frontend exec -- tauri build --bundles nsis,msi
+        run: npm --prefix frontend exec -- tauri build --target ${{ matrix.target }} --bundles nsis,msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -166,14 +194,14 @@ jobs:
       - name: 上传 Windows 安装包产物
         uses: actions/upload-artifact@v4
         with:
-          name: altgo-windows-packages
+          name: altgo-windows-${{ matrix.arch }}-packages
           path: |
-            src-tauri/target/release/bundle/nsis/*-setup.exe
-            src-tauri/target/release/bundle/nsis/*-setup.exe.sig
-            src-tauri/target/release/bundle/nsis/*-setup.nsis.zip*
-            src-tauri/target/release/bundle/nsis/latest.json
-            src-tauri/target/release/bundle/msi/*.msi
-            src-tauri/target/release/bundle/msi/*.msi.zip*
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.exe
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.exe.sig
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.nsis.zip*
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/latest.json
+            src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
+            src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi.zip*
           if-no-files-found: warn
 
   gen-aur:
@@ -255,8 +283,8 @@ jobs:
           mapfile -t appimages < <(find release-assets -type f -name '*.AppImage' | sort)
           mapfile -t exes < <(find release-assets -type f -name '*-setup.exe' | sort)
           mapfile -t msis < <(find release-assets -type f -name '*.msi' | sort)
-          if [[ "${#debs[@]}" -ne 2 || "${#rpms[@]}" -ne 2 || "${#appimages[@]}" -ne 2 || "${#exes[@]}" -ne 1 || "${#msis[@]}" -ne 1 ]]; then
-            echo "错误：预期两份 deb、两份 rpm、两份 AppImage、一份 exe 和一份 msi，实际为 ${#debs[@]} 份 deb、${#rpms[@]} 份 rpm、${#appimages[@]} 份 AppImage、${#exes[@]} 份 exe、${#msis[@]} 份 msi" >&2
+          if [[ "${#debs[@]}" -ne 2 || "${#rpms[@]}" -ne 2 || "${#appimages[@]}" -ne 2 || "${#exes[@]}" -ne 2 || "${#msis[@]}" -ne 2 ]]; then
+            echo "错误：预期两份 deb、两份 rpm、两份 AppImage、两份 exe 和两份 msi（Windows x64 与 arm64 各一份），实际为 ${#debs[@]} 份 deb、${#rpms[@]} 份 rpm、${#appimages[@]} 份 AppImage、${#exes[@]} 份 exe、${#msis[@]} 份 msi" >&2
             find release-assets -type f | sort >&2
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Build artifacts
 /target/
 /src-tauri/target/
-altgo
-altgo.exe
+/altgo
+/altgo.exe
 
 # Test artifacts
 test.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **Windows arm64 支持**：sherpa-onnx 升级至 1.13.6（上游已发布 Windows arm64 预编译库），CI 与 Release 工作流新增 `aarch64-pc-windows-msvc` 架构构建，发布产物新增 arm64 的 NSIS 安装包与 MSI（#131）。
+
 ## v2.6.4 (2026-08-24)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **altgo** 是一款桌面语音转文字工具。按住触发键说话，松开后自动完成录音、转写和可选润色，结果写入系统剪贴板并显示在悬浮窗中。
 
-支持 **Linux**（Ubuntu 22.04+）的 **x86_64** 与 **aarch64** 架构，以及 **Windows 10+**（x86_64）。目前不支持 macOS。
+支持 **Linux**（Ubuntu 22.04+）的 **x86_64** 与 **aarch64** 架构，以及 **Windows 10+**（x86_64 与 arm64）。目前不支持 macOS。
 
 - [在线文档](https://cislunarspace.github.io/altgo/)
 - [下载 Releases](https://github.com/cislunarspace/altgo/releases)
@@ -66,7 +66,7 @@ sudo usermod -aG input "$USER"
 - `*-setup.exe`（NSIS 安装器）：双击安装，适合大多数用户。
 - `*.msi`：适合需要 MSI 部署方式的企业环境。
 
-仅支持 Windows x64（内嵌的 sherpa-onnx 预编译库暂无 Windows arm64 版本）。安装后在开始菜单启动 altgo，在设置页完成转写配置。
+x64 与 arm64 请按设备架构选择对应的安装包。安装后在开始菜单启动 altgo，在设置页完成转写配置。
 
 ## 快速开始
 

--- a/docs-site/docs/quick-start.mdx
+++ b/docs-site/docs/quick-start.mdx
@@ -5,7 +5,7 @@ title: 快速开始
 
 # 快速开始
 
-本软件支持 **Linux**（Ubuntu 22.04+）的 **x86_64** 与 **aarch64** 架构。Linux 构建和 Release 在 **Ubuntu 22.04** 上验证；其他发行版可能可用但未保证。目前不支持 Windows 和 macOS。
+本软件支持 **Linux**（Ubuntu 22.04+）的 **x86_64** 与 **aarch64** 架构，以及 **Windows 10+**（x86_64 与 arm64）。Linux 构建和 Release 在 **Ubuntu 22.04** 上验证；其他发行版可能可用但未保证。目前不支持 macOS。
 
 转写引擎内嵌 sherpa-onnx（SenseVoice），无需单独安装任何二进制。
 
@@ -30,6 +30,12 @@ sudo usermod -aG input "$USER"
    - 按需配置 **润色**、**外观**、**触发键**（可用「按下以设置」）；
    - 点击 **保存**。
 4. 识别结果会**写入剪贴板**并在**悬浮窗**中展示；需要时可在悬浮窗内再次复制。
+
+### Windows
+
+1. 从 [Releases](https://github.com/cislunarspace/altgo/releases) 下载与设备架构（x64 或 arm64）对应的 **`*-setup.exe`**（NSIS 安装器）或 **`*.msi`**。
+2. 双击安装，在开始菜单启动 altgo。
+3. 打开 **设置**，完成模型下载、润色、触发键等配置后点击 **保存**。
 
 
 **不要**把「先复制 `configs/altgo.toml` 再手改」当作默认路径——那是高级用法。日常用户只使用界面即可。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 altgo 是基于 Tauri 的桌面语音转文字工具：Rust 后端承载整条语音流水线，React 前端负责设置页、历史页与悬浮窗。两个收敛后的设计前提：
 
 - **转写只有一条路径**：本地 SenseVoice（内嵌 sherpa-onnx），模型常驻内存。whisper.cpp、Whisper API、MiMo ASR 已随 #121 删除。
-- **平台为 Linux（Ubuntu 22.04+，x86_64/aarch64）与 Windows 10+（x86_64）**。旧的 PowerShell 式 Windows 适配曾随 #121 删除，现行实现（`windows.rs`）为原生 API 重写：WH_KEYBOARD_LL 钩子监听按键、cpal/WASAPI 录音、arboard 剪贴板 + SendInput 文本注入。
+- **平台为 Linux（Ubuntu 22.04+，x86_64/aarch64）与 Windows 10+（x86_64/arm64）**。旧的 PowerShell 式 Windows 适配曾随 #121 删除，现行实现（`windows.rs`）为原生 API 重写：WH_KEYBOARD_LL 钩子监听按键、cpal/WASAPI 录音、arboard 剪贴板 + SendInput 文本注入。
 
 核心设计只有一句话：**业务核心与框架彻底解耦，平台能力一律收进 trait seam**。`voice_pipeline` 模块完全不 import Tauri，只通过 `PipelineSink`、`TranscriptionDispatch`、`OverlaySink` 等 trait seam 与外界交互；按键监听、录音、剪贴板等系统能力也都被收进各自 trait 后面，各平台实现命名为 `linux.rs` / `windows.rs`。
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,8 +107,8 @@ Linux 平台接缝：
 
 - `ci.yml` 的 check job 在 ubuntu-22.04（amd64）与 ubuntu-22.04-arm（arm64）各跑全量 `cargo test --manifest-path=src-tauri/Cargo.toml --lib`
 - 前端测试、`cargo fmt --all -- --check`、`cargo clippy --all-targets -- -D warnings`（测试代码也过编译检查）只在 amd64 job 跑一次
-- `ci.yml` 的 check-windows job 在 windows-latest 跑 `cargo test --lib` 并构建 NSIS 包
-- `release.yml` 的 test job 同样双架构跑 `cargo test --lib`；deb/rpm 打包（build-linux）`needs: test`，发版前必须过两种架构的测试；NSIS 打包（build-windows）`needs: validate` 并在打包前跑测试
+- `ci.yml` 的 check-windows job 在 windows-latest 跑 `cargo test --lib` 并构建 NSIS 包（x64 与 arm64 两个架构）
+- `release.yml` 的 test job 同样双架构跑 `cargo test --lib`；deb/rpm 打包（build-linux）`needs: test`，发版前必须过两种架构的测试；NSIS 打包（build-windows）`needs: validate`，覆盖 Windows x64 与 arm64，并在打包前跑测试
 
 **基线要求**：全量全绿，无 `#[ignore]`，无静默跳过。改动落在哪层，测试随代码补在哪层。若改动的风险只有端到端层能覆盖（如安装包真实启动），在 PR 里说明手动验证方式。
 

--- a/packaging/scoop/README.md
+++ b/packaging/scoop/README.md
@@ -1,0 +1,17 @@
+# Scoop 清单（ScoopInstaller/Extras 提交流程）
+
+`altgo.json` 是提交到 [ScoopInstaller/Extras](https://github.com/ScoopInstaller/Extras)
+的清单，直接复用 Release 的 NSIS 安装包（Scoop 用 7zip 解压 NSIS，`altgo.exe` 位于根目录，
+已实际验证）。
+
+## 提交流程
+
+1. fork `ScoopInstaller/Extras`，把 `altgo.json` 放到 `bucket/` 目录，提 PR。
+2. 清单含 `checkver`（GitHub release）与 `autoupdate`（sha256 从 Release 的
+   `checksums.txt` 提取），之后发版由 Extras 的自动更新机器人跟进，无需手工维护。
+
+## 注意
+
+- `pre_install` 清理 NSIS 解压残留（`$PLUGINSDIR`、卸载器），这是 Extras 中
+  NSIS 包的通行写法。
+- 待 Windows arm64 构建（#131）落地后，在 `architecture` 下追加 `arm64` 条目即可。

--- a/packaging/scoop/altgo.json
+++ b/packaging/scoop/altgo.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.6.4",
+    "description": "桌面语音转文字工具：按住触发键说话，松开后自动转写并写入剪贴板",
+    "homepage": "https://github.com/cislunarspace/altgo",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cislunarspace/altgo/releases/download/v2.6.4/altgo_2.6.4_x64-setup.exe#/dl.7z",
+            "hash": "4ccbd0f71c69eff981036aa8eed11cefa49e7013012189a33bcbbbfe1d9f2ac8"
+        }
+    },
+    "pre_install": [
+        "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "Remove-Item \"$dir\\`$TEMP\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "Get-ChildItem \"$dir\" -Filter 'Uninstall*.exe' | Remove-Item -Force"
+    ],
+    "bin": "altgo.exe",
+    "shortcuts": [
+        [
+            "altgo.exe",
+            "altgo"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/cislunarspace/altgo"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cislunarspace/altgo/releases/download/v$version/altgo_$version_x64-setup.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/cislunarspace/altgo/releases/download/v$version/checksums.txt",
+            "regex": "(?m)^([a-f0-9]{64})\\s+\\./nsis/altgo_$version_x64-setup\\.exe$"
+        }
+    }
+}

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,29 @@
+# winget 清单（microsoft/winget-pkgs 提交流程）
+
+本目录存放提交到 [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) 的清单，
+基于 GitHub Release 已发布的 MSI / NSIS 安装包。
+
+## 提交流程
+
+1. 发版后更新 `manifests/` 下对应版本目录中的 `PackageVersion`、`InstallerUrl` 与
+   `InstallerSha256`（sha256 取自 Release 的 `checksums.txt`）。
+2. 本地校验：
+
+   ```powershell
+   winget validate --manifest packaging\winget\manifests\c\cislunarspace\altgo\<版本>\
+   ```
+
+3. fork `microsoft/winget-pkgs`，把清单放到
+   `manifests/c/cislunarspace/altgo/<版本>/`，提 PR。也可用
+   [wingetcreate](https://github.com/microsoft/winget-create) 生成并直接发起 PR：
+
+   ```powershell
+   wingetcreate new https://github.com/cislunarspace/altgo/releases/download/v<版本>/altgo_<版本>_x64-setup.exe
+   ```
+
+## 注意
+
+- winget 要求首个提交的包先通过人工审核，之后的版本更新可走自动化。
+- MSI 的 `ProductCode` 每次构建都会变（Tauri 未固定），如改用 MSI 清单需逐版本更新。
+- 目前 Release 仅有 x64 安装包；待 Windows arm64 构建（#131）落地后，在
+  installer 清单中追加 `Architecture: arm64` 条目即可。

--- a/packaging/winget/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.installer.yaml
+++ b/packaging/winget/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.installer.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: cislunarspace.altgo
+PackageVersion: 2.6.4
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/cislunarspace/altgo/releases/download/v2.6.4/altgo_2.6.4_x64-setup.exe
+    InstallerSha256: 4ccbd0f71c69eff981036aa8eed11cefa49e7013012189a33bcbbbfe1d9f2ac8
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/packaging/winget/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.locale.zh-CN.yaml
+++ b/packaging/winget/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.locale.zh-CN.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: cislunarspace.altgo
+PackageVersion: 2.6.4
+PackageLocale: zh-CN
+Publisher: cislunarspace
+PackageName: altgo
+License: MIT
+ShortDescription: 桌面语音转文字工具，按住触发键说话，松开后自动转写并写入剪贴板
+Description: |-
+  altgo 是一款桌面语音转文字工具。按住触发键说话，松开后自动完成录音、
+  本地 SenseVoice 转写和可选的 LLM 润色，结果写入系统剪贴板并显示在悬浮窗中。
+PackageUrl: https://github.com/cislunarspace/altgo
+Tags:
+  - speech-to-text
+  - asr
+  - voice
+  - sensevoice
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/packaging/winget/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.yaml
+++ b/packaging/winget/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.yaml
@@ -1,0 +1,8 @@
+# Created for altgo
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: cislunarspace.altgo
+PackageVersion: 2.6.4
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4230,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "sherpa-onnx"
-version = "1.13.5"
+version = "1.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352a5dbbd9623e800be27e77de514e87fcfe2120256acc4434e6ea87a56bc885"
+checksum = "93440301c4240bd5d83496ab9adeee889be48d9428f9c01c37e5ae4ef33ba9e2"
 dependencies = [
  "serde",
  "serde_json",
@@ -4241,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "sherpa-onnx-sys"
-version = "1.13.5"
+version = "1.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1541926ecf70b3d806467a2f100d3d879eef7fd34f8b307028bb074871d7493"
+checksum = "4d627abc4624c845e628ad87cca4ff9ac265fc643021d155f2721ac589eeb324"
 dependencies = [
  "bzip2",
  "tar",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1"
 thiserror = "1"
 sha2 = "0.10"
-sherpa-onnx = "1.13.5"
+sherpa-onnx = "1.13.6"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = [


### PR DESCRIPTION
## 关联 issue

- Closes #131（CI 通过后关闭）
- Ref #130（winget / Scoop 清单就绪，issue 保持跟踪 Flatpak / Snap）

## 改动摘要

### Windows arm64 支持（#131）

上游 sherpa-onnx v1.13.6 已发布 Windows arm64 预编译库，原阻塞解除：

- `sherpa-onnx` 依赖 1.13.5 → 1.13.6
- `ci.yml` 的 `check-windows` 改为 x64/arm64 矩阵；arm64 为交叉编译，x64 runner 无法执行 arm64 测试二进制，故 arm64 仅 `cargo check` 验证编译（与 issue 待办一致），x64 维持完整测试
- `release.yml` 的 `build-windows` 同步双架构，产出 arm64 NSIS 安装包与 MSI；发布产物校验相应改为两份 exe、两份 msi
- README、docs-site 快速开始、docs/architecture、docs/testing 同步平台说明
- 附带修复：`.gitignore` 的 `altgo` 模式锚定到根目录（否则 winget 清单中的 `altgo/` 目录被误忽略）

### winget / Scoop 提交清单（#130）

- `packaging/winget/`：winget-pkgs 三件式清单（version / installer / locale），基于已发布的 v2.6.4 NSIS x64 包，sha256 取自 Release `checksums.txt`，本机 `winget validate` 通过；附提交流程说明
- `packaging/scoop/altgo.json`：Extras 风格清单，NSIS 包经 7zip 解压安装（已验证压缩包结构与 hash），含 `checkver`/`autoupdate`
- 清单提交到 winget-pkgs / ScoopInstaller/Extras 需 fork 外部仓库手动进行；Flatpak / Snap 沙箱可行性验证仍待 PoC，#130 保持 open

## 测试

- `cargo test --lib`：225 通过
- `cargo clippy --all-targets -- -D warnings`：通过
- `cargo fmt --check`：通过
- workflow / 清单 YAML 语法校验通过；winget 清单 `winget validate` 通过
- arm64 链接正确性本地无法验证（缺 MSVC arm64 工具链），依赖本 PR 的 CI arm64 job 确认